### PR TITLE
Autoload step modules based on feature file name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,9 @@ with both `@interface` and `@database` at the same time.
 Scoped steps are really just Ruby modules under the covers so you
 can do anything you'd normally want to do including defining
 helper/utility methods and variables.  Check out
-[features/alignment_steps.rb](features/alignment_steps.rb) and
-[features/evil_steps.rb](features/evil_steps.rb) for basic examples.
+[features/alignment_steps.rb](https://github.com/jnicklas/turnip/blob/master/examples/alignment_steps.rb)
+and
+[features/evil_steps.rb](https://github.com/jnicklas/turnip/blob/master/examples/evil_steps.rb) for basic examples.
 
 ### Reusing steps
 When using scoped steps in Turnip, you can tell it to also include steps

--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ with both `@interface` and `@database` at the same time.
 
 Scoped steps are really just Ruby modules under the covers so you
 can do anything you'd normally want to do including defining
-helper/utility methods and variables.  Check out `features/alignment_steps.rb`
-and `features/evil_steps.rb` for basic examples.
+helper/utility methods and variables.  Check out
+[features/alignment_steps.rb](features/alignment_steps.rb) and
+[features/evil_steps.rb](features/evil_steps.rb) for basic examples.
 
 ### Reusing steps
 When using scoped steps in Turnip, you can tell it to also include steps
@@ -211,9 +212,9 @@ Notice in this example we are making full use of Ruby's modules including
 using super to call the included module's version of `dragon_attack`.
 
 ### Auto-included steps
-By default, Turnip will automatically make steps available to a
-feature file if it can find some defined in a scope with the same
-name.  For example, given this step file:
+By default, Turnip will automatically make available any steps defined in 
+a `steps_for` block with the same name as the feature file being run.  For
+example, given this step file:
 
 ``` ruby
 # user_signup_steps.rb
@@ -246,6 +247,9 @@ Feature: A user can signup
 Note that the `steps_for :user_signup` did not technically have to
 appear in the user_signup_steps.rb file; it could have been located
 in any `steps.rb` file that was autoloaded by Turnip.
+
+This feature can be turned off using the `Turnip::Config.autotag_features`
+option if desired.
 
 ## Custom step placeholders
 Do you want to be more specific in what to match in your step

--- a/examples/autoload_steps.feature
+++ b/examples/autoload_steps.feature
@@ -1,0 +1,5 @@
+Feature: Auto-loaded steps
+  
+  @scenario_tag
+  Scenario:
+    Given an auto-loaded step is available

--- a/examples/autoload_steps.rb
+++ b/examples/autoload_steps.rb
@@ -1,0 +1,5 @@
+steps_for :autoload_steps do
+  step 'an auto-loaded step is available' do
+    true.should be
+  end
+end

--- a/lib/turnip.rb
+++ b/lib/turnip.rb
@@ -6,6 +6,7 @@ require "turnip/dsl"
 
 module Turnip
   autoload :Config, 'turnip/config'
+  autoload :FeatureFile, 'turnip/feature_file'
   autoload :Loader, 'turnip/loader'
   autoload :Builder, 'turnip/builder'
   autoload :StepDefinition, 'turnip/step_definition'
@@ -16,11 +17,11 @@ module Turnip
   class << self
     attr_accessor :type
 
-    def run(content)
-      Turnip::Builder.build(content).features.each do |feature|
+    def run(feature_file)
+      Turnip::Builder.build(feature_file).features.each do |feature|
         describe feature.name, feature.metadata_hash do
 
-          feature_tags = Turnip::StepModule.active_tags(feature.metadata_hash.keys)
+          feature_tags = feature.active_tags.uniq
 
           feature.backgrounds.each do |background|
             before do
@@ -32,7 +33,7 @@ module Turnip
           feature.scenarios.each do |scenario|
             context scenario.metadata_hash do
 
-              scenario_tags = Turnip::StepModule.active_tags(feature.metadata_hash.keys + scenario.metadata_hash.keys)
+              scenario_tags = (feature_tags + scenario.active_tags).uniq
               Turnip::StepModule.modules_for(*scenario_tags).each { |mod| include mod }
 
               it scenario.name do

--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -122,8 +122,8 @@ module Turnip
 
     def feature(feature)
       @current_feature = Feature.new(feature)
-      # Automatically add a tag based on the name of the feature to the Feature
-      @current_feature.feature_tag = @feature_file.feature_name
+      # Automatically add a tag based on the name of the feature to the Feature if configured to
+      @current_feature.feature_tag = @feature_file.feature_name if Turnip::Config.autotag_features
       @features << @current_feature
     end
 

--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -4,6 +4,10 @@ module Turnip
       def tags
         @raw.tags.map { |tag| tag.name.sub(/^@/, '') }
       end
+      
+      def active_tags
+        tags.map(&:to_sym)
+      end
 
       def tags_hash
         Hash[tags.map { |t| [t.to_sym, true] }]
@@ -25,11 +29,20 @@ module Turnip
       include Name
 
       attr_reader :scenarios, :backgrounds
+      attr_accessor :feature_tag
 
       def initialize(raw)
         @raw = raw
         @scenarios = []
         @backgrounds = []
+      end
+      
+      # Feature's active_tags automatically prepends the :global tag
+      # as well as its feature_tag if defined
+      def active_tags
+        active_tags = [:global]
+        active_tags << feature_tag.to_sym if feature_tag
+        active_tags + super
       end
 
       def metadata_hash
@@ -88,16 +101,17 @@ module Turnip
     attr_reader :features
 
     class << self
-      def build(content)
-        Turnip::Builder.new.tap do |builder|
+      def build(feature_file)
+        Turnip::Builder.new(feature_file).tap do |builder|
           formatter = Gherkin::Formatter::TagCountFormatter.new(builder, {})
           parser = Gherkin::Parser::Parser.new(formatter, true, "root", false)
-          parser.parse(content, nil, 0)
+          parser.parse(feature_file.content, nil, 0)
         end
       end
     end
 
-    def initialize
+    def initialize(feature_file)
+      @feature_file = feature_file
       @features = []
     end
 
@@ -108,6 +122,8 @@ module Turnip
 
     def feature(feature)
       @current_feature = Feature.new(feature)
+      # Automatically add a tag based on the name of the feature to the Feature
+      @current_feature.feature_tag = @feature_file.feature_name
       @features << @current_feature
     end
 

--- a/lib/turnip/config.rb
+++ b/lib/turnip/config.rb
@@ -1,7 +1,9 @@
 module Turnip
   module Config
     extend self
-        
+    
+    attr_accessor :autotag_features
+    
     def step_dirs
       @step_dirs ||= ['spec']
     end
@@ -12,3 +14,5 @@ module Turnip
     end
   end
 end
+
+Turnip::Config.autotag_features = true

--- a/lib/turnip/config.rb
+++ b/lib/turnip/config.rb
@@ -1,7 +1,7 @@
 module Turnip
   module Config
     extend self
-
+        
     def step_dirs
       @step_dirs ||= ['spec']
     end

--- a/lib/turnip/feature_file.rb
+++ b/lib/turnip/feature_file.rb
@@ -1,0 +1,20 @@
+module Turnip
+  class FeatureFile
+    attr_accessor :file_name, :content, :feature_name
+    
+    def initialize(file_name)
+      @file_name = file_name
+    end
+    
+    def feature_name
+      @feature_name ||= begin
+        file = Pathname.new(file_name).basename.to_s
+        file[0...file.index('.feature')]
+      end
+    end
+    
+    def content
+      @content ||= File.read(file_name)
+    end
+  end
+end

--- a/lib/turnip/loader.rb
+++ b/lib/turnip/loader.rb
@@ -3,8 +3,7 @@ module Turnip
     def load(*a, &b)
       if a.first.end_with?('.feature')
         require 'spec_helper'
-        content = File.read(a.first)
-        Turnip.run(content)
+        Turnip.run(Turnip::FeatureFile.new(a.first))
       else
         super
       end

--- a/lib/turnip/step_module.rb
+++ b/lib/turnip/step_module.rb
@@ -45,10 +45,6 @@ module Turnip
 
     extend self
 
-    def active_tags(tags)
-      [:global] + tags
-    end
-
     def all_steps_for(*taggings)
       modules_for(*taggings).map do |step_module|
         step_module.steps

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -48,5 +48,22 @@ describe Turnip::Builder do
         feature.scenarios.first.active_tags.should eq([:scenario_tag])
       end
     end
+    
+    context "autotag features disabled" do
+      before(:each) { Turnip::Config.autotag_features = false }
+      after(:each) { Turnip::Config.autotag_features = true }
+      
+      let(:feature_file) { Turnip::FeatureFile.new(File.expand_path('../examples/autoload_steps.feature', File.dirname(__FILE__))) }
+      let(:builder) { Turnip::Builder.build(feature_file) }
+      let(:feature) { builder.features.first }
+      
+      it 'should automatically include the :global tag for features' do
+        feature.active_tags.should include(:global)
+      end
+      
+      it 'should not automatically include the feature name tag for features' do
+        feature.active_tags.should_not include(:autoload_steps)
+      end
+    end
   end
 end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe Turnip::Builder do
   context "with scenario outlines" do
-    let(:gherkin) { File.read(File.expand_path('../examples/scenario_outline.feature', File.dirname(__FILE__))) }
-    let(:builder) { Turnip::Builder.build(gherkin) }
+    let(:feature_file) { Turnip::FeatureFile.new(File.expand_path('../examples/scenario_outline.feature', File.dirname(__FILE__))) }
+    let(:builder) { Turnip::Builder.build(feature_file) }
     let(:feature) { builder.features.first }
 
 
@@ -25,6 +25,28 @@ describe Turnip::Builder do
         "I attack the monster and do 5 points damage",
         "the monster should be alive"
       ])
+    end
+  end
+  
+  describe "taggings" do
+    let(:feature_file) { Turnip::FeatureFile.new(File.expand_path('../examples/autoload_steps.feature', File.dirname(__FILE__))) }
+    let(:builder) { Turnip::Builder.build(feature_file) }
+    let(:feature) { builder.features.first }
+    
+    context "for features" do
+      it 'should automatically include the :global tag for features' do
+        feature.active_tags.should include(:global)
+      end
+      
+      it 'should automatically include the feature name tag for features' do
+        feature.active_tags.should include(:autoload_steps)
+      end
+    end
+    
+    context "for scenarios" do
+      it 'should only include scenario tags' do
+        feature.scenarios.first.active_tags.should eq([:scenario_tag])
+      end
     end
   end
 end

--- a/spec/feature_file_spec.rb
+++ b/spec/feature_file_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Turnip::FeatureFile do
+  let(:file_name) {File.expand_path('../examples/with_comments.feature', File.dirname(__FILE__))}
+  let(:feature_file) {Turnip::FeatureFile.new(file_name)}
+  
+  describe '.feature_name' do
+    it 'allows access to short name for the feature based on the file name' do
+      feature_file.feature_name.should == 'with_comments'
+    end
+  end
+  
+  describe '.content' do
+    it 'allows access to the content in the feature file' do
+      feature_file.content.should be
+    end
+  end
+end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -11,6 +11,6 @@ describe 'The CLI', :type => :integration do
   end
 
   it "prints out failures and successes" do
-    @result.should include('18 examples, 1 failure, 1 pending')
+    @result.should include('19 examples, 1 failure, 1 pending')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,4 @@
 RSpec.configure do |config|
   Turnip::Config.step_dirs = 'examples'
   Turnip::StepModule.load_steps
-
-  config.before(:each, :turnip => true) do
-  end
 end


### PR DESCRIPTION
This adds the feature I had mentioned on Les' pull request to automatically load the step modules for a feature based on its file name.

For examples see:

examples/autoload_steps.feature
examples/autoload_steps.rb

It essentially automatically adds a tag at the feature level (similar to :global) based on the file name.  So in the example above it saves you from having to tag the feature with @autoload_steps and does that for you automatically.  A more typical Rails example would be a feature file named user_signup.feature and a steps file with steps_for :user_signup defined.

There is also a config option added to disable this feature.
