### PR TITLE
Add support for verticle tables when describing single objects

### DIFF
--- a/lib/turnip/table.rb
+++ b/lib/turnip/table.rb
@@ -20,9 +20,21 @@ module Turnip
     def hashes
       rows.map { |row| Hash[headers.zip(row)] }
     end
+    
+    def rows_hash
+      return @rows_hash if @rows_hash
+      verify_table_width(2)
+      @rows_hash = self.class.new(raw.transpose).hashes[0]
+    end
 
     def each
       @raw.each { |row| yield(row) }
+    end
+    
+    private
+    
+    def verify_table_width(width)
+      raise %{The table must have exactly #{width} columns} unless raw[0].size == width
     end
   end
 end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -30,12 +30,19 @@ describe Turnip::Table do
   end
 
   describe '#hashes' do
-    it 'returns a list of hashe based on the headers' do
+    it 'returns a list of hashes based on the headers' do
       table = Turnip::Table.new([['foo', 'bar'], ['moo', '55'], ['quox', '42']])
       table.hashes.should == [
         {'foo' => 'moo', 'bar' => '55'},
         {'foo' => 'quox', 'bar' => '42'}
       ]
+    end
+  end
+  
+  describe '#rows_hash' do
+    it 'converts this table into a Hash where the first column is used as keys and the second column is used as values' do
+      table = Turnip::Table.new([['foo', 'moo'], ['bar', '55']])
+      table.rows_hash.should == {'foo' => 'moo', 'bar' => '55'}
     end
   end
 


### PR DESCRIPTION
This was basically yanked straight from Cucumber.  Allows you to define single objects in a table vertically instead of horizontally.

Mostly added this in because that's what Fabrication prefers:

``` cucumber
  Scenario: a single detailed object
    Given the following author:
      | name | George Orwell |
    Then I should see 1 author in the database
    And I should see the following author in the database:
      | name | George Orwell |
```
