### PR TITLE
Adds version requirement to turnip's gherkin gem dependency.  

### DIFF
--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", "~>2.0"
-  s.add_runtime_dependency "gherkin"
+  s.add_runtime_dependency "gherkin", ">= 2.5"
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
This is a quick fix to a minor dependency issue I found while adding Turnip to one of my projects.

It looks like the gherkin gem prior to version 2.5 did not include a Gherkin::Formatter::Model::Step#doc_string method.  

This causes turnip specs to fail when running on a system that has gherkin gem, but an older version.  

With gherkin v2.5 or greater, all Turnip specs pass.
