### PR TITLE
Error when running with Spork

### DIFF
--- a/lib/turnip.rb
+++ b/lib/turnip.rb
@@ -4,6 +4,8 @@ require "gherkin/formatter/tag_count_formatter"
 require "turnip/version"
 require "turnip/dsl"
 
+require 'rspec'
+
 module Turnip
   autoload :Config, 'turnip/config'
   autoload :FeatureFile, 'turnip/feature_file'


### PR DESCRIPTION
When attempting to run in a new rails application with Spork I receive an error:

```
Using RSpec
Preloading Rails environment
uninitialized constant RSpec::Core (NameError)
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/turnip-0.2.0/lib/turnip.rb:42:in `<top (required)>'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/bundler-1.0.21/lib/bundler/runtime.rb:68:in `require'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/bundler-1.0.21/lib/bundler/runtime.rb:68:in `block (2 levels) in require'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/bundler-1.0.21/lib/bundler/runtime.rb:66:in `each'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/bundler-1.0.21/lib/bundler/runtime.rb:66:in `block in require'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/bundler-1.0.21/lib/bundler/runtime.rb:55:in `each'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/bundler-1.0.21/lib/bundler/runtime.rb:55:in `require'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/bundler-1.0.21/lib/bundler.rb:122:in `require'
/Users/xxx/code/app/config/application.rb:7:in `<top (required)>'
/Users/xxx/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
/Users/xxx/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/spork-0.9.0.rc9/lib/spork/app_framework/rails.rb:48:in `preload_rails'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/spork-0.9.0.rc9/lib/spork/app_framework/rails.rb:7:in `preload'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/spork-0.9.0.rc9/lib/spork/test_framework.rb:134:in `block in preload'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/spork-0.9.0.rc9/lib/spork.rb:62:in `exec_prefork'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/spork-0.9.0.rc9/lib/spork/test_framework.rb:120:in `preload'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/spork-0.9.0.rc9/lib/spork/run_strategy/forking.rb:25:in `preload'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/spork-0.9.0.rc9/lib/spork/runner.rb:74:in `run'
/Users/xxx/.rvm/gems/ruby-1.9.3-p0@app/gems/spork-0.9.0.rc9/lib/spork/runner.rb:10:in `run'
```

I could not come up with a good way to test this, but all tests do pass after making this change.

To reproduce error:
1. Create a new rails application
2. Configure Rspec
3. Add Spork to Gemfile
4. Bootstrap spork
5. Confirm that everything is working by running 'spork'
6. Add turnip to Gemfile
7. Running 'spork' from command line generates error.

Tested with 

rails 3.1.3
turnip 0.2.0
rspec 2.7.0
spork 0.9.0.rc9

Let me know if there is anything else that I can do, I am a little green when it comes to pull requests.
