### PR TITLE
Remove multiple tags on steps_for dsl

### DIFF
--- a/lib/turnip/dsl.rb
+++ b/lib/turnip/dsl.rb
@@ -8,8 +8,8 @@ module Turnip
       global_step_module_entry.step_module.steps << Turnip::StepDefinition.new(description, &block)
     end
 
-    def steps_for(*taggings, &block)
-      Turnip::StepModule.steps_for(*taggings, &block)
+    def steps_for(tag, &block)
+      Turnip::StepModule.steps_for(tag, &block)
     end
 
     private

--- a/lib/turnip/step_module.rb
+++ b/lib/turnip/step_module.rb
@@ -24,12 +24,12 @@ module Turnip
       end
     end
 
-    class Entry < Struct.new(:for_taggings, :step_module, :uses_steps)
+    class Entry < Struct.new(:for_tag, :step_module, :uses_steps)
       def all_modules(already_visited = [])
-        unless (already_visited & for_taggings).empty?
+        if already_visited.include?(for_tag)
           []
         else
-          already_visited.concat(for_taggings)
+          already_visited << for_tag
           uses_modules(already_visited) << step_module
         end
       end
@@ -71,14 +71,12 @@ module Turnip
       module_registry.has_key? module_name
     end
 
-    def steps_for(*taggings, &block)
+    def steps_for(tag, &block)
       anon = step_module(&block)
 
-      entry = Entry.new(taggings, anon, anon.uses_steps)
+      entry = Entry.new(tag, anon, anon.uses_steps)
 
-      taggings.each do |tag|
-        module_registry[tag] << entry
-      end
+      module_registry[tag] << entry
     end
 
     def step_module(&block)

--- a/spec/step_module_spec.rb
+++ b/spec/step_module_spec.rb
@@ -6,7 +6,7 @@ describe Turnip::StepModule do
   describe '.modules_for' do
     it 'returns the unique registered modules' do
       Turnip::StepModule.steps_for(:first) {}
-      Turnip::StepModule.steps_for(:first, :second) {}
+      Turnip::StepModule.steps_for(:second) {}
       Turnip::StepModule.modules_for(:first, :second).size.should eq(2)
     end
 
@@ -34,10 +34,9 @@ describe Turnip::StepModule do
   end
 
   describe '.steps_for' do
-    it 'registers for the given tags' do
-      Turnip::StepModule.steps_for(:first, :second) {}
+    it 'registers the given tag' do
+      Turnip::StepModule.steps_for(:first) {}
       Turnip::StepModule.should be_registered(:first)
-      Turnip::StepModule.should be_registered(:second)
     end
 
     it 'registers an anonymous modle for the given tags' do
@@ -45,10 +44,6 @@ describe Turnip::StepModule do
       Turnip::StepModule.module_registry[:first].first.step_module.should be_instance_of(Module)
     end
 
-    it 'registers the same module for multiple tags' do
-      Turnip::StepModule.steps_for(:first, :second) {}
-      Turnip::StepModule.module_registry[:first].first.should eq(Turnip::StepModule.module_registry[:second].first)
-    end
   end
 
   describe '.step_module' do


### PR DESCRIPTION
There is an open issue for this: No need for the multiple tags anymore, since the <code>use_steps</code> feature.
