### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Now edit the `.rspec` file in your project directory (create it if doesn't
 exist), and add the following line:
 
 ```
--r turnip
+-rturnip
 ```
 
 ## Development


### PR DESCRIPTION
This is a very tiny change to the README to make sure Turnip gets run when you load the entire suite.  There is a difference between rspec -r turnip and rspec -rturnip when I run it on rspec 2.8.0.  The former with a space will run the specs, but not features.  The latter will run the specs then the features as expected.  Not sure if this is a bug with rspec, but the space between -r and turnip causes the feature files to get ignored, but the directory pattern still gets included.
