### PR TITLE
TravisCI fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ rvm:
  - 1.9.2
  - 1.9.3
  - ruby-head
- - rbx-2.0
+ - rbx-19mode
+


### PR DESCRIPTION
TravisCI removed the rbx-2.0 alias and instead now rbx-19mode and rbx-18 mode will be used, since all the other rubies are 1.9 I decided to go with 1.9 mode - it is experimental though, hope it works. [For more info see their guide](http://about.travis-ci.org/docs/user/languages/ruby/)

I hope that this way turnip can go back to green again :-)
