### PR TITLE
Add transpose method to Table class

### DIFF
--- a/lib/turnip/table.rb
+++ b/lib/turnip/table.rb
@@ -22,7 +22,7 @@ module Turnip
     end
 
     def rows_hash
-      raise %{The table must have exactly #{width} columns} unless width == 2
+      raise WidthMismatch.new(2, width) unless width == 2
       transpose.hashes.first
     end
 
@@ -38,6 +38,12 @@ module Turnip
 
     def width
       raw[0].size
+    end
+
+    class WidthMismatch < StandardError
+      def initialize(expected, actual)
+        super("Expected the table to be #{expected} columns wide, got #{actual}")
+      end
     end
   end
 end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -60,7 +60,7 @@ describe Turnip::Table do
       let(:raw) { [["a", "b", "c"], ["1", "2", "3"]] }
 
       it 'raises an error' do
-        expect { table.rows_hash }.to raise_error
+        expect { table.rows_hash }.to raise_error Turnip::Table::WidthMismatch
       end
     end
   end


### PR DESCRIPTION
Allows for 2 column tables to be transposed. For example: 

| Name  | Dave |
| Age     | 99     |
| Height | 6ft     |

Could deprecate existing "rows_hash" method

Also, DRYs up table_spec 
