### PR TITLE
Fixes failing integration spec.

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -11,6 +11,6 @@ describe 'The CLI', :type => :integration do
   end
 
   it "prints out failures and successes" do
-    @result.should include('23 examples, 1 failure, 2 pending')
+    @result.should include('24 examples, 1 failure, 2 pending')
   end
 end


### PR DESCRIPTION
This fixes the integration spec that started failing after merging in b1938b7.  Going to merge this right in.
