### PR TITLE
Add support for mixed quotes in placeholder strings

### DIFF
--- a/examples/interpolation.feature
+++ b/examples/interpolation.feature
@@ -12,6 +12,10 @@ Feature: A simple feature
     Given there is a monster called John
     Then it should be called "John"
 
+  Scenario: Interpolation with mixed quotes
+    Given there is a monster called "O'Flannahan"
+    Then it should be called "O'Flannahan"
+
   Scenario: Interpolation with customer regexp
     Given there are 3 monkeys with blue hair
     Then there should be 3 monkeys with blue hair

--- a/examples/steps.rb
+++ b/examples/steps.rb
@@ -32,6 +32,10 @@ step 'it should be called "John"' do
   @monster_name.should == "John"
 end
 
+step 'it should be called "O\'Flannahan"' do
+  @monster_name.should == "O'Flannahan"
+end
+
 step "I change its name to :empty_string" do |empty_string|
   @monster_name = empty_string
 end

--- a/lib/turnip/placeholder.rb
+++ b/lib/turnip/placeholder.rb
@@ -27,8 +27,8 @@ module Turnip
 
       def default
         @default ||= new(:default) do
-          match %r((?:["']([^["']]*)["']|([a-zA-Z0-9_-]+))) do |first, second|
-            first or second
+          match %r((?:"([^"]*)"|'([^']*)'|([a-zA-Z0-9_-]+))) do |first, second, third|
+            first or second or third
           end
         end
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -11,6 +11,6 @@ describe 'The CLI', :type => :integration do
   end
 
   it "prints out failures and successes" do
-    @result.should include('25 examples, 1 failure, 2 pending')
+    @result.should include('26 examples, 1 failure, 2 pending')
   end
 end


### PR DESCRIPTION
We had a situation where we were trying to match text with a single quote within double quotes and it caused the step to not match the definition. Something like:

`And I should see "Conan O'Brien"`

A slight regexp adjustment fixed it right up.
