### PR TITLE
Workaround for 1.9.2 compatibility in printing test failures

### DIFF
--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -90,6 +90,11 @@ module Turnip
     end
 
     class Step < Struct.new(:description, :extra_args, :line)
+      # 1.9.2 support hack
+      def split(*args)
+        self.to_s.split(*args)
+      end
+
       def to_s
         description
       end


### PR DESCRIPTION
I noticed Travis was failing for 1.9.2 and starting looking into it. I'm not totally happy with the solution, but it doesn't interfere with any tested functionality in 1.9.2 or 1.9.3.

Notes if someone wants to attempt a more sophisticated fix:
It seems like rspec's formatter is ending up with with a Turnip::Builder::Step object when it wants a String for a test failure's exception. The path through rspec appeared to be completely different in 1.9.3.
