### PR TITLE
Corrects issue with using the same custom placeholder multiple times

### DIFF
--- a/lib/turnip/step_definition.rb
+++ b/lib/turnip/step_definition.rb
@@ -19,7 +19,7 @@ module Turnip
       result = description.match(regexp)
       if result
         params = result.captures
-        result.names.each_with_index do |name, index|
+        @placeholder_names.each_with_index do |name, index|
           params[index] = Turnip::Placeholder.apply(name.to_sym, params[index])
         end
         Match.new(self, params, block)
@@ -33,8 +33,10 @@ module Turnip
     ALTERNATIVE_WORD_REGEXP = /(\w+)((\/\w+)+)/
 
     def compile_regexp
+      @placeholder_names = []
       regexp = Regexp.escape(expression)
       regexp.gsub!(PLACEHOLDER_REGEXP) do |_|
+        @placeholder_names << "#{$1}"
         "(?<#{$1}>#{Placeholder.resolve($1.to_sym)})"
       end
       regexp.gsub!(OPTIONAL_WORD_REGEXP) do |_|

--- a/spec/step_definition_spec.rb
+++ b/spec/step_definition_spec.rb
@@ -36,6 +36,23 @@ describe Turnip::StepDefinition do
       match.params.should eq(["3", "2"])
     end
 
+    it "does search for the same custom placeholder several times" do
+      placeholder = Turnip::Placeholder.add(:count) { match(/\d/) { |count| count.to_i } }
+      Turnip::Placeholder.stub(:resolve).with(:count).and_return(/\d+/)
+      Turnip::Placeholder.should_receive(:find).with(:count).twice.and_return(placeholder)
+      step = Turnip::StepDefinition.new(":count monsters and :count knights") {}
+      match = step.match("3 monsters and 2 knights")
+      #match.params.should eq([3, 2])
+    end
+
+    it "does apply the same custom placeholder several times" do
+      placeholder = Turnip::Placeholder.add(:count) { match(/\d/) { |count| count.to_i } }
+      Turnip::Placeholder.stub(:resolve).with(:count).and_return(/\d+/)
+      placeholder.should_receive(:apply).twice
+      step = Turnip::StepDefinition.new(":count monsters and :count knights") {}
+      match = step.match("3 monsters and 2 knights")
+    end
+
     it "matches quoted placeholders" do
       step = Turnip::StepDefinition.new("there is a monster named :name") {}
       step.should match("there is a monster named 'Scary'")


### PR DESCRIPTION
There is an issue when using a custom placeholder several times: it only gets applied the first time.

I've added 2 examples showing the issue in `step_definition_spec.rb` and patched `step_definition.rb` to correct the issue.

It is due to the way `String#match` build the result's `names` when the same name is used several times:

```
irb(main):006:0> "3 monsters and 2 knights".match(%r{(?-mix:^(?<count>(?-mix:\d+))\ monsters\ and\ (?<count>(?-mix:\d+))\ knights$)}).names
=> ["count"]
```

Maybe this depends on the Ruby version? I'm using `1.9.2-p290`. 
