### PR TITLE
Allow specifying a different spec helper file

### DIFF
--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -4,6 +4,12 @@ require "rspec"
 module Turnip
   module RSpec
 
+    class << self
+      attr_accessor :spec_helper
+    end
+
+    self.spec_helper = 'spec_helper'
+
     ##
     #
     # This module hooks Turnip into RSpec by duck punching the load Kernel
@@ -13,7 +19,7 @@ module Turnip
       def load(*a, &b)
         if a.first.end_with?('.feature')
           begin
-            require 'spec_helper'
+            require Turnip::RSpec.spec_helper
           rescue LoadError
           end
           Turnip::RSpec.run(a.first)


### PR DESCRIPTION
In some cases it can be beneficial to have a spec helper specific to the acceptance specs. For example, my `spec_helper.rb` contains only the absolute minimum setup (load paths etc.)
