### PR TITLE
JRuby bugfix: Java Gherkin throwing NullPointerException: uri

### DIFF
--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -106,7 +106,7 @@ module Turnip
       def build(feature_file)
         Turnip::Builder.new.tap do |builder|
           parser = Gherkin::Parser::Parser.new(builder, true)
-          parser.parse(File.read(feature_file), nil, 0)
+          parser.parse(File.read(feature_file), feature_file, 0)
         end
       end
     end


### PR DESCRIPTION
Hi, thank you for making Turnip.

I'm using JRuby.  When running a .feature, [this exception is thrown](https://gist.github.com/3103026):

```
Parser.java:181:in `<init>': java.lang.NullPointerException: uri
    from Parser.java:66:in `pushMachine'
    from Parser.java:56:in `parse'
    ...
```

That's Gherkin complaining.  It turns out with JRuby a native Java Gherkin is used and it's picky about how it's parse method is called: when featureURI is null, the above exception results.  [Excerpts from Parser.java](https://github.com/cucumber/gherkin/blob/master/java/src/main/java/gherkin/parser/Parser.java):

``` java
/**
* @param featureURI the URI where the gherkin originated from. Typically a file path.
* @param lineOffset the line offset within the uri document the gherkin was taken from. Typically 0.
*/
public void parse(String gherkin, String featureURI, Integer lineOffset) {
```

``` java
public Machine(Parser parser, String name, String uri) {
  if (uri == null) {
    throw new NullPointerException("uri");
```

By passing feature_file as the featureURI, Java Gherkin is happy!
