### PR TITLE
Allow failures in at travis-ci for ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ rvm:
  - 1.9.3
  - ruby-head
  - rbx-19mode
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 


### PR DESCRIPTION
As discussed, allowing failures on travis-ci for ruby-head. Worked on my travis setup. This sould fix #69 .
