### PR TITLE
Don't hide LoadError exceptions raised in the spec helper

### DIFF
--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -12,12 +12,22 @@ module Turnip
     module Loader
       def load(*a, &b)
         if a.first.end_with?('.feature')
-          begin; require 'turnip_helper'; rescue LoadError; end
-          begin; require 'spec_helper'; rescue LoadError; end
+          require_if_exists 'turnip_helper'
+          require_if_exists 'spec_helper'
+
           Turnip::RSpec.run(a.first)
         else
           super
         end
+      end
+
+      private
+
+      def require_if_exists(filename)
+        require filename
+      rescue LoadError => e
+        # Don't hide LoadErrors raised in the spec helper.
+        raise unless e.message.include?(filename)
       end
     end
 


### PR DESCRIPTION
This fixes a bug where a LoadError raised in the spec helper (or one of its dependencies) would be discarded. The specs would still run, but fail for weird and uninstuitive reasons.
