### PR TITLE
rewrote lib/turnip/table.rb #headers to use symbols instead of strings

### DIFF
--- a/examples/steps/steps.rb
+++ b/examples/steps/steps.rb
@@ -63,12 +63,12 @@ end
 step "there are the following monsters:" do |table|
   @monsters = {}
   table.hashes.each do |hash|
-    @monsters[hash['Name']] = hash['Hitpoints'].to_i
+    @monsters[hash[:Name].to_sym] = hash[:Hitpoints].to_i
   end
 end
 
 step ":name should have :count hitpoints" do |name, count|
-  @monsters[name].should eq(count.to_i)
+  @monsters[name.to_sym].should eq(count.to_i)
 end
 
 step "the monster sings the following song" do |song|

--- a/lib/turnip/table.rb
+++ b/lib/turnip/table.rb
@@ -10,7 +10,7 @@ module Turnip
     end
 
     def headers
-      raw.first
+      raw.first.map {|s| s = s.to_sym}
     end
 
     def rows

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -40,9 +40,9 @@ describe Turnip::Builder do
         "the monster should be dead"
       ])
       table = feature.scenarios[0].steps[0].extra_args.find {|a| a.instance_of?(Turnip::Table)}
-      table.hashes[0]['hit_points'].should == '10'
+      table.hashes[0][:hit_points].should == '10'
       table = feature.scenarios[1].steps[0].extra_args.find {|a| a.instance_of?(Turnip::Table)}
-      table.hashes[0]['hit_points'].should == '8'
+      table.hashes[0][:hit_points].should == '8'
     end
 
   end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -23,7 +23,7 @@ describe Turnip::Table do
 
   describe '#headers' do
     it 'returns the first row' do
-      table.headers.should == ['foo', 'bar']
+      table.headers.should == [:foo, :bar]
     end
   end
 
@@ -38,8 +38,8 @@ describe Turnip::Table do
     let(:raw) { [['foo', 'bar'], ['moo', '55'], ['quox', '42']] }
     it 'returns a list of hashes based on the headers' do
       table.hashes.should == [
-        {'foo' => 'moo', 'bar' => '55'},
-        {'foo' => 'quox', 'bar' => '42'}
+        {:foo => 'moo', :bar => '55'},
+        {:foo => 'quox', :bar => '42'}
       ]
     end
   end
@@ -49,7 +49,7 @@ describe Turnip::Table do
 
       let(:raw) { [["Name", "Dave"], ["Age", "99"], ["Height", "6ft"]] }
       it 'transposes the raw table' do
-        table.transpose.hashes.should == [{ "Name" => "Dave", "Age" => "99", "Height" => "6ft" }]
+        table.transpose.hashes.should == [{ :Name => "Dave", :Age => "99", :Height => "6ft" }]
       end
     end
   end
@@ -57,7 +57,7 @@ describe Turnip::Table do
   describe '#rows_hash' do
     let(:raw) { [['foo', 'moo'], ['bar', '55']] }
     it 'converts this table into a Hash where the first column is used as keys and the second column is used as values' do
-      table.rows_hash.should == {'foo' => 'moo', 'bar' => '55'}
+      table.rows_hash.should == {:foo => 'moo', :bar => '55'}
     end
 
     context "when table is greater than 2 columns wide" do


### PR DESCRIPTION
We had issues with using tables in our features because we would expect `table.hashes.each {|hash| hash[:my_key]` instead of `hash['my_key']` out of convention.

We figured this would be a change that would benefit users of turnip and couldn't think of any particular reason that you had wanted to use string keys instead of symbol keys.

All specs are passing and example features (except those that purposefully raise errors) pass too.
