### PR TITLE
Allow Turnip::Table#hashes to be accessed by string or symbol keys

### DIFF
--- a/lib/turnip/table.rb
+++ b/lib/turnip/table.rb
@@ -1,4 +1,22 @@
 module Turnip
+  class HashWithIndifferentAccess < Hash
+    def initialize hash = Hash.new
+      super
+
+      hash.each do |k,v|
+        self[k] = v
+      end
+
+      self.default_proc = Proc.new{|h,k|
+        if k.is_a?(String) && h.has_key?(k.to_sym)
+          h[k.to_sym]
+        elsif k.is_a?(Symbol) && h.has_key?(k.to_s)
+          h[k.to_s]
+        end
+      }
+    end
+  end
+  
   class Table
     attr_reader :raw
     alias_method :to_a, :raw
@@ -18,7 +36,7 @@ module Turnip
     end
 
     def hashes
-      rows.map { |row| Hash[headers.zip(row)] }
+      rows.map { |row| HashWithIndifferentAccess.new(Hash[headers.zip(row)]) }
     end
 
     def rows_hash

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -42,6 +42,13 @@ describe Turnip::Table do
         {'foo' => 'quox', 'bar' => '42'}
       ]
     end
+
+    it 'returns a list of hashes with indiferent access' do
+      table.hashes.each do |hash|
+        hash[:foo].should == hash['foo']
+        hash[:bar].should == hash['bar']
+      end
+    end
   end
 
   describe '#transpose' do


### PR DESCRIPTION
# The Problem

We've been wasting time trying to figure out why our tests are failing and it was due to us expecting the Table#hashes to return hashes with symbol keys (which is the convention) and we get nils.
## First Attempt

I tried to fix this the first time around by mapping the strings to symbols in the `Table#headers` definition but you didn't like that because if someone had a header in their table like "Foo Bar" it wouldn't map well.
# The Solution Now

I created a class called HashWithIndifferentAccess (I know there's a rails class called the same but this is not that) that sets the `default_proc` (which is run when you request from a hash instance a key a that it doesn't contain). This proc first checks to see if the key is a string or a symbol, then to see if there is a key which is of the other respective type in this hash. If there is then it returns that value, if not it returns nil, like usual.

How about that?
