### PR TITLE
Add `turnip/kanban` for implementing a kanban-style workflow

### DIFF
--- a/lib/turnip/kanban.rb
+++ b/lib/turnip/kanban.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |config|
+    config.treat_symbols_as_metadata_keys_with_true_values = true
+    config.run_all_when_everything_filtered = true
+    config.filter_run_excluding :backlog
+    config.filter_run_including :wip
+end


### PR DESCRIPTION
A workflow I (and others I have worked with) commonly use is to write out a number of scenarios when we start on a new card. We then tag all the scenarios as `@backlog` to show that these scenarios are not implemented yet. Then, we tag the first scenario as `@wip` and start working on it. Once it's complete, we remove the tag and continue on. These tags allow us to commit early and often rather than waiting until all the scenarios are complete before pushing work. I call it a "Kanban" workflow, since I've typically used it on teams that use a pull-based workflow.

I've implemented the RSpec tag configuration for this enough that it would be nice to be able to just `require "turnip/kanban"` and have it setup for me. Is this something you would consider having in Turnip core?
