### PR TITLE
Table#map_column! method

### DIFF
--- a/lib/turnip/table.rb
+++ b/lib/turnip/table.rb
@@ -34,6 +34,15 @@ module Turnip
       raw.each { |row| yield(row) }
     end
 
+    def map_column!(name, strict = true)
+      index = headers.index(name.to_s)
+      if index.nil?
+        raise ColumnNotExist.new(name) if strict
+      else
+        rows.each { |row| row[index] = yield(row[index]) }
+      end
+    end
+
     private
 
     def width
@@ -43,6 +52,12 @@ module Turnip
     class WidthMismatch < StandardError
       def initialize(expected, actual)
         super("Expected the table to be #{expected} columns wide, got #{actual}")
+      end
+    end
+
+    class ColumnNotExist < StandardError
+      def initialize(column_name)
+        super("The column named \"#{column_name}\" does not exist")
       end
     end
   end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -77,4 +77,22 @@ describe Turnip::Table do
     end
   end
 
+  describe '#map_column!' do
+    let(:raw) { [['name', 'age'], ['Dave', '31'], ['John', '45']] }
+    it 'iterates through the column value and assigns it the value returned by the block' do
+      table.map_column!(:age) { |age| age.to_i }
+      table.rows.should == [['Dave', 31], ['John', 45]]
+    end
+
+    context 'with undefined column' do
+
+      it 'raies an error' do
+        expect { table.map_column!(:undefined){} }.to raise_error Turnip::Table::ColumnNotExist
+      end
+      it 'not raises an error when the strict param is false' do
+        expect { table.map_column!(:undefined, false){} }.to_not raise_error
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Adds #map_column! method to Table class. This method iterates through the column and assigns it the value returned by the block. Is identical to the same method in the cucumber.
Scenario:

``` gherkin
Scenario: ...
  Given the following posts:
    | user | article |
    | Dave | post1   |
    | John | post2   |
```

Step:

``` ruby
step "the following posts:" do |table|
  table.map_column!(:user) { |name| User.find_by_name!(name) }
  table.hashes.each do |post|
    create(:post, post)
  end
end
```

This code raises error if column `user` does not exists in the scenario. If the user column is optional, use `map_column!` with `strict` option is false:

``` ruby
table.map_column!(:user, false) { ... }
```
