### PR TITLE
Automatically load scoped steps by convention

### DIFF
--- a/examples/autoload_steps.feature
+++ b/examples/autoload_steps.feature
@@ -2,5 +2,8 @@
 Feature: Auto-loaded steps
 
   @scenario_tag
-  Scenario:
+  Scenario: Deprecated auto-loaded step
     Given an auto-loaded step is available
+
+  Scenario: Auto-loaded steps module
+    Given a step auto-loaded by module

--- a/examples/steps/autoload_steps_steps.rb
+++ b/examples/steps/autoload_steps_steps.rb
@@ -1,0 +1,5 @@
+module AutoloadStepsSteps
+  step 'a step auto-loaded by module' do
+    true.should be
+  end
+end

--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -59,6 +59,17 @@ module Turnip
               # This is kind of a hack, but it will make RSpec throw way nicer exceptions
               example.metadata[:file_path] = feature_file
 
+              path = Pathname.new(feature_file)
+              default_steps_file = File.join(path.dirname, 'steps', path.basename.to_s.sub('.feature', '_steps.rb'))
+              default_steps_module = [path.basename.to_s.sub('.feature', '').split('_').collect(&:capitalize), 'Steps'].join
+
+              if File.exists?(default_steps_file)
+                require default_steps_file
+                if Module.const_defined?(default_steps_module)
+                  extend Module.const_get(default_steps_module)
+                end
+              end
+
               feature.backgrounds.map(&:steps).flatten.each do |step|
                 run_step(feature_file, step)
               end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -11,7 +11,7 @@ describe 'The CLI', :type => :integration do
   end
 
   it "prints out failures and successes" do
-    @result.should include('35 examples, 3 failures, 5 pending')
+    @result.should include('36 examples, 3 failures, 5 pending')
   end
 
   it "includes features in backtraces" do


### PR DESCRIPTION
This change automatically requires and includes modules for a specific feature as an alternative to manually requiring and including steps in `spec_helper.rb` or using `steps_for(:tag)`. This allows users to write steps that are automatically scoped to a specific feature by naming convention. For example, defining steps for the feature `spec/acceptance/story.feature` in a module named `StorySteps` in the file `spec/acceptance/steps/story_steps.rb` results in the steps defined in `StorySteps` being mixed-in to that example group.

I've personally found this very helpful to have but I'm wondering if perhaps this should only include the modules and leave requiring the files that define them up to the user allowing steps defined in other locations, i.e. `spec/steps`, to also be automatically included in scope.
