### PR TITLE
Fix line numbers and make `rspec -l` work

### DIFF
--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -22,9 +22,16 @@ module Turnip
       end
     end
 
+    module Line
+      def line
+        @raw.line
+      end
+    end
+
     class Feature
       include Tags
       include Name
+      include Line
 
       attr_reader :scenarios, :backgrounds
       attr_accessor :feature_tag
@@ -33,10 +40,6 @@ module Turnip
         @raw = raw
         @scenarios = []
         @backgrounds = []
-      end
-
-      def line
-        @raw.line
       end
 
       def metadata_hash
@@ -55,6 +58,7 @@ module Turnip
     class Scenario
       include Tags
       include Name
+      include Line
 
       attr_accessor :steps
 

--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -64,13 +64,14 @@ module Turnip
               end
             end
             feature.scenarios.each do |scenario|
-              describe scenario.name, scenario.metadata_hash do
-                it scenario.steps.map(&:description).join(' -> ') do
-                  scenario.steps.each do |step|
-                    run_step(feature_file, step)
+              instance_eval <<-EOS, feature_file, scenario.line
+                describe scenario.name, scenario.metadata_hash do it(scenario.steps.map(&:description).join(' -> ')) do
+                    scenario.steps.each do |step|
+                      run_step(feature_file, step)
+                    end
                   end
                 end
-              end
+              EOS
             end
           end
         end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -17,4 +17,17 @@ describe 'The CLI', :type => :integration do
   it "includes features in backtraces" do
     @result.should include('examples/errors.feature:5:in `raise error')
   end
+
+  it 'prints line numbers of pending/failure scenario' do
+    @result.should include('./examples/pending.feature:2')
+    @result.should include('./examples/errors.feature:4')
+  end
+
+  it 'conforms to line-number option' do
+    @result.should include('rspec ./examples/errors.feature:4')
+    @result.should include('rspec ./examples/errors.feature:6')
+    result_with_line_number = %x(rspec -fs ./examples/errors.feature:4)
+    result_with_line_number.should include('rspec ./examples/errors.feature:4')
+    result_with_line_number.should_not include('rspec ./examples/errors.feature:6')
+  end
 end


### PR DESCRIPTION
The problem is `rspec example/errors.feature` reports meaningless line numbers.

```
Failed examples:

rspec ./examples/errors.feature:68 # raises errors Step raises error raise error
rspec ./examples/errors.feature:68 # raises errors Incorrect expectation there is a monster -> it should die
```

Moreover, we cannot use `-l` option to filter examples (scenarios) to be executed.

I fixed this problem by faking line numbers with `instance_eval`.
Please check added specs.
