### PR TITLE
Fix tables not working unter JRuby

### DIFF
--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -153,11 +153,14 @@ module Turnip
       if step.doc_string
         extra_args.push step.doc_string.value
       elsif step.rows
-        if step.rows.class.to_s == "Java::JavaUtil::ArrayList"
-          extra_args.push Turnip::Table.new(step.rows.map { |row| row.cells.to_a })
-        else
-          extra_args.push Turnip::Table.new(step.rows.map { |row| row.cells(&:value) })
-        end
+        extra_args.push(Turnip::Table.new(step.rows.map do |row|
+            if step.rows.class.to_s == "Java::JavaUtil::ArrayList"
+              row.cells.to_a
+            else
+              row.cells(&:value)
+            end
+          end
+        ))
       end
       @current_step_context.steps << Step.new(step.name, extra_args, step.line)
     end


### PR DESCRIPTION
Because in JRuby step.rows is an Java::JavaUtil::ArrayList and no Hash it needs to be handled in a different way.
