### PR TITLE
substitute doc string in scenario outline

### DIFF
--- a/examples/scenario_outline_multiline_string_substitution.feature
+++ b/examples/scenario_outline_multiline_string_substitution.feature
@@ -1,0 +1,13 @@
+Feature: using scenario outlines
+  Scenario Outline: a simple outline
+    Given there is a monster called <name>
+    Then the monster introduced himself:
+      """
+      Ahhhhhhh! i'm <name>!
+      """
+
+    Examples:
+      | name          |
+      | John          |
+      | "John Smith"  |
+      | "O'Flannahan" |

--- a/examples/steps/steps.rb
+++ b/examples/steps/steps.rb
@@ -44,6 +44,10 @@ step "it should be nameless" do
   @monster_name.should == ""
 end
 
+step "the monster introduced himself:" do |self_introduction|
+  self_introduction.should include @monster_name
+end
+
 step "there is a monster with :count hitpoints" do |count|
   @monster = count
 end

--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -87,8 +87,14 @@ module Turnip
             scenario.steps = steps.map do |step|
               new_description = substitute(step.description, headers, row)
               new_extra_args = step.extra_args.map do |ea|
-                next ea unless ea.instance_of?(Turnip::Table)
-                Turnip::Table.new(ea.map {|t_row| t_row.map {|t_col| substitute(t_col, headers, row) } })
+                case ea
+                when String
+                  substitute(ea, headers, row)
+                when Turnip::Table
+                  Turnip::Table.new(ea.map {|t_row| t_row.map {|t_col| substitute(t_col, headers, row) } })
+                else
+                  ea
+                end
               end
               Step.new(new_description, new_extra_args, step.line, step.keyword)
             end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -11,7 +11,7 @@ describe 'The CLI', :type => :integration do
   end
 
   it "prints out failures and successes" do
-    @result.should include('35 examples, 3 failures, 5 pending')
+    @result.should include('38 examples, 3 failures, 5 pending')
   end
 
   it "includes features in backtraces" do


### PR DESCRIPTION
I wanna do subsititute doc string :pencil: something like example below(from [Substitution in Scenario Outlines](http://cukes.info/step-definitions.html))

``` feature
Scenario Outline: Email confirmation
  Given I have a user account with my name "Jojo Binks"
  When an Admin grants me <Role> rights
  Then I should receive an email with the body:
    """
    Dear Jojo Binks,
    You have been granted <Role> rights.  You are <details>. Please be responsible.
    -The Admins
    """
  Examples:
    |  Role     | details                                         |
    |  Manager  | now able to manage your employee accounts       |
    |  Admin    | able to manage any user account on the system   |
```
