### PR TITLE
Implemented step `keyword` property

### DIFF
--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -90,7 +90,7 @@ module Turnip
                 next ea unless ea.instance_of?(Turnip::Table)
                 Turnip::Table.new(ea.map {|t_row| t_row.map {|t_col| substitute(t_col, headers, row) } })
               end
-              Step.new(new_description, new_extra_args, step.line)
+              Step.new(new_description, new_extra_args, step.line, step.keyword)
             end
           end
         end
@@ -103,7 +103,7 @@ module Turnip
       end
     end
 
-    class Step < Struct.new(:description, :extra_args, :line)
+    class Step < Struct.new(:description, :extra_args, :line, :keyword)
       # 1.9.2 support hack
       def split(*args)
         self.to_s.split(*args)
@@ -160,7 +160,7 @@ module Turnip
         table = Turnip::Table.new(step.rows.map(&:cells).map(&:to_a))
         extra_args.push(table)
       end
-      @current_step_context.steps << Step.new(step.name, extra_args, step.line)
+      @current_step_context.steps << Step.new(step.name, extra_args, step.line, step.keyword)
     end
 
     def uri(*)

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -19,6 +19,10 @@ describe Turnip::Builder do
     it 'extracts step line' do
       steps.map(&:line).should eq([3, 4, 5])
     end
+
+    it 'extracts step keyword' do
+      steps.map(&:keyword).should eq(['Given ', 'When ', 'Then '])
+    end
   end
 
   context "with scenario outlines" do


### PR DESCRIPTION
## Motivation

I want to provide the necessary and sufficient `step` properties for libraries that use turnip.
(eg.  [turnip_formatter](https://github.com/gongo/turnip_formatter))
