### PR TITLE
Fix supported rspec version

### DIFF
--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "rspec", [">=2.0", "<4.0"]
+  s.add_runtime_dependency "rspec", [">=2.14.0", "<4.0"]
   s.add_runtime_dependency "gherkin", ">= 2.5"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"


### PR DESCRIPTION
In `turnip.gemspec`:

```
  s.add_runtime_dependency "rspec", [">=2.0", "<4.0"]
```

But it seems doesn't work with old rspec :see_no_evil: 
