### PR TITLE
Support more strict behavior of unimplemented steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,18 @@ step "there are the following monsters:" do |table|
 end
 ```
 
+## Unimplemented steps
+Turnip mark a scenario as pending when steps in the scenario is not implemented.
+If you sets `raise_error_for_unimplemented_steps` as `true`, turnip will mark a scenario as fail.
+
+It defaults to `false`, you can change it by following configuration:
+
+```ruby
+RSpec.configure do |config|
+  config.raise_error_for_unimplemented_steps = true
+end
+```
+
 ## Substitution in Scenario Outlines
 
 You would be able to use substitution that can be used to DocString and Table arguments in Scenario Outline like [Cucumber](http://cukes.info/step-definitions.html#substitution_in_scenario_outlines):

--- a/examples/errors.feature
+++ b/examples/errors.feature
@@ -6,3 +6,6 @@ Feature: raises errors
   Scenario: Incorrect expectation
     Given there is a monster
     Then it should die
+  @raise_error_for_unimplemented_steps
+  Scenario: Step missing and raise_error_for_unimplemented_steps is set
+    When a step just does not exist

--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -48,6 +48,11 @@ module Turnip
           example.metadata[:line_number] = step.line
           example.metadata[:location] = "#{example.metadata[:file_path]}:#{step.line}"
 
+          if ::RSpec.configuration.raise_error_for_unimplemented_steps
+            e.backtrace.push "#{feature_file}:#{step.line}:in `#{step.description}'"
+            raise
+          end
+
           if ::RSpec::Version::STRING >= '2.99.0'
             skip("No such step: '#{e}'")
           else
@@ -75,7 +80,7 @@ module Turnip
             before do
               example = Turnip::RSpec.fetch_current_example(self)
               # This is kind of a hack, but it will make RSpec throw way nicer exceptions
-              example.metadata[:file_path] = feature_file
+              example.metadata[:file_path] ||= feature_file
 
               feature.backgrounds.map(&:steps).flatten.each do |step|
                 run_step(feature_file, step)
@@ -104,4 +109,5 @@ end
   config.include Turnip::RSpec::Execute, turnip: true
   config.include Turnip::Steps, turnip: true
   config.pattern << ",**/*.feature"
+  config.add_setting :raise_error_for_unimplemented_steps, :default => false
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -11,11 +11,12 @@ describe 'The CLI', :type => :integration do
   end
 
   it "prints out failures and successes" do
-    @result.should include('38 examples, 3 failures, 5 pending')
+    @result.should include('39 examples, 4 failures, 5 pending')
   end
 
   it "includes features in backtraces" do
     @result.should include('examples/errors.feature:5:in `raise error')
+    @result.should include('examples/errors.feature:11:in `a step just does not exist')
   end
 
   it "includes the right step name when steps call steps" do
@@ -25,13 +26,17 @@ describe 'The CLI', :type => :integration do
   it 'prints line numbers of pending/failure scenario' do
     @result.should include('./examples/pending.feature:3')
     @result.should include('./examples/errors.feature:4')
+    @result.should include('./examples/errors.feature:6')
+    @result.should include('./examples/errors.feature:11')
   end
 
   it 'conforms to line-number option' do
     @result.should include('rspec ./examples/errors.feature:4')
     @result.should include('rspec ./examples/errors.feature:6')
+    @result.should include('rspec ./examples/errors.feature:11')
     result_with_line_number = %x(rspec -fd ./examples/errors.feature:4)
     result_with_line_number.should include('rspec ./examples/errors.feature:4')
     result_with_line_number.should_not include('rspec ./examples/errors.feature:6')
+    result_with_line_number.should_not include('rspec ./examples/errors.feature:11')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,10 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = [:should, :expect]
   end
+
+  config.before(raise_error_for_unimplemented_steps: true) do
+    config.stub(:raise_error_for_unimplemented_steps) { true }
+  end
 end
 
 Dir.glob(File.expand_path("../examples/**/*steps.rb", File.dirname(__FILE__))) { |f| require f }


### PR DESCRIPTION
Sometimes I make a scenario as pending accidentally.
I'd like to change turnip's behavior when the step is undefined, like cucumber's `--strict` option:
https://github.com/cucumber/cucumber/wiki/Step-Definitions#undefined-steps
