### PR TITLE
Remove "circular require" warnings when running turnip's test with `--warnings`

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
--r turnip
+-r turnip/rspec

--- a/lib/turnip.rb
+++ b/lib/turnip.rb
@@ -29,5 +29,3 @@ Turnip.type = :feature
 Module.send(:include, Turnip::Define)
 
 self.extend Turnip::DSL
-
-require "turnip/rspec"


### PR DESCRIPTION
```
$ bundle exec rspec --warnings
/Users/sei/src/github.com/hanachin/turnip/lib/turnip/step_definition.rb:9:
warning: assigned but unused variable - trace
/Users/sei/src/github.com/hanachin/turnip/lib/turnip/rspec.rb:1:
warning: loading in progress, circular require considered harmful -
/Users/sei/src/github.com/hanachin/turnip/lib/turnip.rb
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/rspec:23:in
        `<main>'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/rspec:23:in
        `load'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/exe/rspec:4:in
        `<top (required)>'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:38:in
        `invoke'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:70:in
        `run'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:85:in
        `run'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/runner.rb:96:in
        `setup'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/configuration_options.rb:22:in
        `configure'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/configuration_options.rb:100:in
        `process_options_into'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/configuration_options.rb:100:in
        `each'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/configuration_options.rb:101:in
        `block in process_options_into'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/configuration.rb:1024:in
        `requires='
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/configuration.rb:1024:in
        `each'
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/configuration.rb:1024:in
        `block in requires='
        from
        /opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rspec-core-3.0.2/lib/rspec/core/configuration.rb:1024:in
        `require'
        from
        /Users/sei/src/github.com/hanachin/turnip/lib/turnip.rb:33:in
        `<top (required)>'
        from
        /Users/sei/src/github.com/hanachin/turnip/lib/turnip.rb:33:in
        `require'
        from
        /Users/sei/src/github.com/hanachin/turnip/lib/turnip/rspec.rb:1:in
        `<top (required)>'
        from
        /Users/sei/src/github.com/hanachin/turnip/lib/turnip/rspec.rb:1:in
        `require'
```
