### PR TITLE
Output the step keyword on documentation format

### DIFF
--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -116,7 +116,7 @@ module Turnip
       end
 
       def to_s
-        description
+        "#{keyword}#{description}"
       end
     end
 

--- a/lib/turnip/execute.rb
+++ b/lib/turnip/execute.rb
@@ -1,11 +1,16 @@
 module Turnip
   module Execute
-    def step(description, *extra_args)
-      extra_args.concat(description.extra_args) if description.respond_to?(:extra_args)
+    def step(step_or_description, *extra_args)
+      if step_or_description.respond_to?(:extra_args)
+        description = step_or_description.description
+        extra_args.concat(step_or_description.extra_args)
+      else
+        description = step_or_description
+      end
 
       matches = methods.map do |method|
         next unless method.to_s.start_with?("match: ")
-        send(method.to_s, description.to_s)
+        send(method.to_s, description)
       end.compact
 
       if matches.length == 0

--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -88,7 +88,7 @@ module Turnip
             end
             feature.scenarios.each do |scenario|
               instance_eval <<-EOS, feature_file, scenario.line
-                describe scenario.name, scenario.metadata_hash do it(scenario.steps.map(&:description).join(' -> ')) do
+                describe scenario.name, scenario.metadata_hash do it(scenario.steps.map(&:to_s).join(' -> ')) do
                     scenario.steps.each do |step|
                       run_step(feature_file, step)
                     end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -23,6 +23,14 @@ describe Turnip::Builder do
     it 'extracts step keyword' do
       steps.map(&:keyword).should eq(['Given ', 'When ', 'Then '])
     end
+
+    it 'extracts full description' do
+      steps.map(&:to_s).should eq([
+        'Given there is a monster',
+        'When I attack it',
+        'Then it should die'
+      ])
+    end
   end
 
   context "with scenario outlines" do

--- a/spec/define_and_execute_spec.rb
+++ b/spec/define_and_execute_spec.rb
@@ -41,13 +41,13 @@ describe Turnip::Execute do
   end
 
   it "can be executed with a builder step" do
-    builder_step = double(:to_s => "a cool step", :extra_args => [])
+    builder_step = double(:description => "a cool step", :extra_args => [])
     mod.step("a :test step") { |test| test.upcase }
     obj.step(builder_step).should == "COOL"
   end
 
   it "sends in extra arg from a builder step" do
-    builder_step = double(:to_s => "a cool step", :extra_args => ["foo"])
+    builder_step = double(:description => "a cool step", :extra_args => ["foo"])
     mod.step("a :test step") { |test, foo| test.upcase + foo }
     obj.step(builder_step).should == "COOLfoo"
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -7,7 +7,8 @@ describe 'The CLI', :type => :integration do
 
   it "shows the correct description" do
     @result.should include('A simple feature')
-    @result.should include('is a simple feature')
+    @result.should include('This is a simple feature')
+    @result.should include('Given there is a monster -> When I attack it -> Then it should die')
   end
 
   it "prints out failures and successes" do


### PR DESCRIPTION
Previous output:

```
A simple feature
  This is a simple feature
    there is a monster -> I attack it -> it should die
```

Current output:

```
A simple feature
  This is a simple feature
    Given there is a monster -> When I attack it -> Then it should die
```

[Fixes #135]
