### PR TITLE
Add plural names as Placeholder.

### DIFF
--- a/lib/turnip/dsl.rb
+++ b/lib/turnip/dsl.rb
@@ -1,7 +1,9 @@
 module Turnip
   module DSL
-    def placeholder(name, &block)
-      Turnip::Placeholder.add(name, &block)
+    def placeholder(*name, &block)
+      name.each do |n|
+        Turnip::Placeholder.add(n, &block)
+      end
     end
 
     def step(description, &block)

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -55,5 +55,11 @@ describe Turnip::DSL do
       context.placeholder('example') { true }
       Turnip::Placeholder.send(:placeholders).should have_key('example')
     end
+
+    it 'registers the multi placeholder globally' do
+      context.placeholder('example_1', 'example_2') { true }
+      Turnip::Placeholder.send(:placeholders).should have_key('example_1')
+      Turnip::Placeholder.send(:placeholders).should have_key('example_2')
+    end
   end
 end


### PR DESCRIPTION
- Previous

```
placeholder :password do 
  match /valid/ do 
    'foo@example.com'
  end
end
placeholder :confirmation_password do 
  match /valid/ do 
    'foo@example.com'
  end
end
```
- After

```
placeholder :password, :confirmation_password do 
  match /valid/ do 
    'foo@example.com'
  end
end
```
