### PR TITLE
Set pattern parameter thorugh `pattern=`

### DIFF
--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -110,6 +110,6 @@ end
 ::RSpec.configure do |config|
   config.include Turnip::RSpec::Execute, turnip: true
   config.include Turnip::Steps, turnip: true
-  config.pattern << ",**/*.feature"
+  config.pattern += ',**/*.feature'
   config.add_setting :raise_error_for_unimplemented_steps, :default => false
 end


### PR DESCRIPTION
refs GH-143

If set `pattern` parameter through `patrern=`, will be used preferentially **option parameter** even if `RSpec.configure.pattern=`
- https://github.com/rspec/rspec-core/blob/v3.0.4/lib/rspec/core/configuration.rb#L187
- [RSpec::Configuration.define_reader](https://github.com/rspec/rspec-core/blob/v3.0.4/lib/rspec/core/configuration.rb#L39-L44)
- https://github.com/rspec/rspec-core/blob/v3.0.4/lib/rspec/core/configuration.rb#L1304
- https://github.com/rspec/rspec-core/blob/v3.0.4/lib/rspec/core/configuration.rb#L1286

But, If append `pattern` parameter not through `pattern=`, will be used **option parameter + append parameter**

:cloud: `config.pattern <<` mean `@pattern <<`. 

So, problem of GH-143  occur. Example:
1. Set option in `.rspec`
   
   ```
   --pattern spec/{**/*_spec.rb,acceptance/**/*.feature}
   ```
   - This is set to [@peferred_options[:pattern]](https://github.com/rspec/rspec-core/blob/v3.0.4/lib/rspec/core/configuration.rb#L313)
2. Use [config.pattern <<](https://github.com/jnicklas/turnip/blob/v1.2.3/lib/turnip/rspec.rb#L111)
   - `@peferred_options[:pattern]` is `spec/{**/*_spec.rb,acceptance/**/*.feature},**/*.feature`

`spec/{**/*_spec.rb,acceptance/**/*.feature},**/*.feature` is..:

```
spec/
    **/*_spec.rb
    acceptance/**/*.feature
**/*.feature
```
