### PR TITLE
Remove assigned but unused variable - trace

### DIFF
--- a/lib/turnip/step_definition.rb
+++ b/lib/turnip/step_definition.rb
@@ -6,7 +6,7 @@ module Turnip
       def called_from; step_definition.called_from; end
 
       def trace
-        trace = %{  - "#{expression}" (#{called_from})}
+        %{  - "#{expression}" (#{called_from})}
       end
     end
 


### PR DESCRIPTION
Running rspec in a rails project was producing:

```
turnip-1.2.4/lib/turnip/step_definition.rb:9: warning: assigned but unused variable - trace
```
