### PR TITLE
update README: remove unwanted arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ your steps wherever you want, and load them however you like. For example, if
 you were to put your steps in `spec/steps`, you could load them like this:
 
 ``` ruby
-Dir.glob("spec/steps/**/*steps.rb") { |f| load f, true }
+Dir.glob("spec/steps/**/*steps.rb") { |f| load f }
 ```
 
 Before loading your `spec_helper`, Turnip also tries to load a file called


### PR DESCRIPTION
`Kernel#load(filename,  wrap=false)`

> If the optional wrap parameter is true, the loaded script will be executed under an anonymous module, protecting the calling program’s global namespace.

This is not what we want here.