### PR TITLE
Support RSpec 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: ruby
 sudo: false
 cache: bundler
 
+branches:
+  only:
+    - master
+
 matrix:
   allow_failures:
     - gemfile: Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ gemfile:
 - gemfiles/Gemfile-rspec-3.0.x
 - gemfiles/Gemfile-rspec-3.1.x
 - gemfiles/Gemfile-rspec-3.2.x
+- gemfiles/Gemfile-rspec-3.3.x

--- a/gemfiles/Gemfile-rspec-3.3.x
+++ b/gemfiles/Gemfile-rspec-3.3.x
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in turnip.gemspec
+gemspec :path => '..'
+
+gem 'rspec', '~> 3.3.0'


### PR DESCRIPTION
Congrats :tada: [RSpec 3.3 has been released!](http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/)

## Known Bugs

Location-based identification doesn't work. Example:

### demo

RSpec 3.2.x or earlier:

```
$ bundle exec rspec examples/errors.feature:4

(skip)

1 example, 1 failure

Failed examples:

rspec ./examples/errors.feature:4 # raises errors Step raises error When raise error
```

RSpec 3.3.1:

```
$ bundle exec rspec examples/errors.feature:4

(skip)

4 examples, 3 failures, 1 pending

Failed examples:

rspec ./examples/errors.feature:4 # raises errors Step raises error When raise error
rspec ./examples/errors.feature:6 # raises errors Incorrect expectation Given there is a monster -> Then it should die
rspec ./examples/errors.feature:11 # raises errors Step missing and raise_error_for_unimplemented_steps is set When a step just does not exist
```

### Because

- From RSpec 3.3.0, the specified location and id are checked using `metadata[:rerun_file_path]`.
    - https://github.com/rspec/rspec-core/blob/v3.3.0/lib/rspec/core/filter_manager.rb#L102-L107
- In the current `turnip` gem, `metadata[:rerun_file_path]` will always `lib/turnip/rspec.rb`.
    - https://github.com/rspec/rspec-core/blob/v3.3.0/lib/rspec/core/metadata.rb#L141-L154
    - https://github.com/jnicklas/turnip/blob/v1.3.0/lib/turnip/rspec.rb#L81
