### PR TITLE
Lock gherkin version to 2.x

### DIFF
--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
-  s.add_runtime_dependency "gherkin", ">= 2.5"
+  s.add_runtime_dependency "gherkin", "~> 2.5"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
 end


### PR DESCRIPTION
See:

- GH-169
- https://github.com/cucumber/gherkin/commit/d47add1a5e1a835af8c5dd9f55f7fe7a4916c7dd