### PR TITLE
Provide a default regexp for custom placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,16 @@ Then I should see 'Danger! Monsters ahead!'
  And I should not see 'Game over!'
 ```
 
+You can also define custom placeholder without specific regexp, that matches the same value of the default placeholder like this:
+
+```ruby
+placeholder :monster_name do
+  match do |name|
+    Monster.find_by!(name: name)
+  end
+end
+```
+
 ## Table Steps
 
 Turnip also supports steps that take a table as a parameter similar to Cucumber:

--- a/examples/steps/steps.rb
+++ b/examples/steps/steps.rb
@@ -65,14 +65,14 @@ step "the monster should be dead" do
 end
 
 step "there are the following monsters:" do |table|
-  @monsters = {}
+  $monsters = {}
   table.hashes.each do |hash|
-    @monsters[hash['Name']] = hash['Hitpoints'].to_i
+    $monsters[hash['Name']] = hash['Hitpoints'].to_i
   end
 end
 
-step ":name should have :count hitpoints" do |name, count|
-  @monsters[name].should eq(count.to_i)
+step ":monster should have :count hitpoints" do |monster, count|
+  monster.should eq(count.to_i)
 end
 
 step "the monster sings the following song" do |song|
@@ -116,5 +116,11 @@ end
 placeholder :color do
   match /blue|green|red/ do |color|
     color.to_sym
+  end
+end
+
+placeholder :monster do
+  match do |name|
+    $monsters[name]
   end
 end

--- a/lib/turnip/placeholder.rb
+++ b/lib/turnip/placeholder.rb
@@ -27,7 +27,7 @@ module Turnip
 
       def default
         @default ||= new(:default) do
-          match %r((?:"([^"]*)"|'([^']*)'|([[:alnum:]_-]+))) do |first, second, third|
+          match do |first, second, third|
             first or second or third
           end
         end
@@ -45,7 +45,7 @@ module Turnip
       if match and match.block then match.block.call(*params) else value end
     end
 
-    def match(regexp, &block)
+    def match(regexp = %r((?:"([^"]*)"|'([^']*)'|([[:alnum:]_-]+))), &block)
       @matches << Match.new(regexp, block)
     end
 

--- a/lib/turnip/placeholder.rb
+++ b/lib/turnip/placeholder.rb
@@ -27,8 +27,8 @@ module Turnip
 
       def default
         @default ||= new(:default) do
-          match do |first, second, third|
-            first or second or third
+          match do |value|
+            value
           end
         end
       end
@@ -45,7 +45,7 @@ module Turnip
       if match and match.block then match.block.call(*params) else value end
     end
 
-    def match(regexp = %r((?:"([^"]*)"|'([^']*)'|([[:alnum:]_-]+))), &block)
+    def match(regexp = %r{['"]?((?:(?<=")[^"]*)(?=")|(?:(?<=')[^']*(?='))|(?<!['"])[[:alnum:]_-]+(?!['"]))['"]?}, &block)
       @matches << Match.new(regexp, block)
     end
 

--- a/spec/placeholder_spec.rb
+++ b/spec/placeholder_spec.rb
@@ -73,10 +73,13 @@ describe Turnip::Placeholder do
       placeholder = described_class.new(:test) do
         match(/foo/) { :foo_bar }
         match(/\d/) { |num| num.to_i }
+        match { |value| value.gsub(' ', '').to_sym }
       end
 
       expect(placeholder.apply('foo')).to eq :foo_bar
-      expect(placeholder.apply('bar')).to eq 'bar'
+      expect(placeholder.apply('bar')).to eq :bar
+      expect(placeholder.apply('"fizz buzz"')).to eq :fizzbuzz
+      expect(placeholder.apply("'fizz buzz'")).to eq :fizzbuzz
       expect(placeholder.apply('5')).to eq 5
     end
 


### PR DESCRIPTION
Sometimes I wrote custom placeholder something like below:

```rb
placeholder :user_name do
  match /.*/ do |user_name|
    User.find_by!(name: user_name)
  end
end
```

I want define custom placeholder but regexp.
Most custom placeholder that I wrote doesn't need special regexp.

Currently, Turnip doesn't expose the default placeholder regexp to the public, so we can't use it.

If provide a default regexp for match DSL, it makes more easy way to define custom placeholder.