### PR TITLE
Provide `default` DSL to use instead of `match` without regexp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ You can also define custom placeholder without specific regexp, that matches the
 
 ```ruby
 placeholder :monster_name do
-  match do |name|
+  default do |name|
     Monster.find_by!(name: name)
   end
 end

--- a/examples/steps/steps.rb
+++ b/examples/steps/steps.rb
@@ -120,7 +120,7 @@ placeholder :color do
 end
 
 placeholder :monster do
-  match do |name|
+  default do |name|
     $monsters[name]
   end
 end

--- a/spec/placeholder_spec.rb
+++ b/spec/placeholder_spec.rb
@@ -71,9 +71,12 @@ describe Turnip::Placeholder do
   describe '#apply' do
     it 'extracts a captured expression and passes to the block' do
       placeholder = described_class.new(:test) do
+        default { |value| value.gsub(' ', '').to_sym }
         match(/foo/) { :foo_bar }
         match(/\d/) { |num| num.to_i }
-        match { |value| value.gsub(' ', '').to_sym }
+
+        # It will be ignored (does not override first `default`)
+        default { |value| value.gsub(' ', '-').to_sym }
       end
 
       expect(placeholder.apply('foo')).to eq :foo_bar


### PR DESCRIPTION
## Purpose

Improvement of #173 

## Motivation

Without regexp `match` that have been implemented in #173 is very useful.
But there is anxiety and surprise such as ":hushed: < I don't know what to match".

So, rename without regexp `match` to `default`. (example from https://github.com/jnicklas/turnip/pull/173#issuecomment-178299935)

```ruby
placeholder :user_name do
  match /admin: (.*)/ do |user_name|
    User.find_by!(name: user_name, role: :admin)
  end

  match /superuser: (.*)/ do |user_name|
    User.find_by!(name: user_name, role: :super)
  end

  default do |user_name|
    User.find_by!(name: user_name)
  end
end
```