### PR TITLE
Turnip supports Ruby 2.1.0+ (remove 2.0.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache: bundler
 branches:
   only:
     - master
-    - 2_0_0_rc1
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
     - rvm: ruby-head
 
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Please create a topic branch for every separate change you make.
 
 ### 1. Ruby
 
-- Support Ruby 2.x
-- Does not support Ruby 1.9.X
+- Support Ruby 2.1 or higher
+- Does not support Ruby 1.9.X and 2.0.X
 - Does not work on Ruby 1.8.X
 
 ### 2. RSpec


### PR DESCRIPTION
Ruby 2.0 is EOL since 24 Feb 2016

See: [Support plans for Ruby 2.0.0 and Ruby 2.1](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/)