### PR TITLE
Fix the problem: string without quotes is devided needless

### DIFF
--- a/lib/turnip/placeholder.rb
+++ b/lib/turnip/placeholder.rb
@@ -64,11 +64,20 @@ module Turnip
   private
 
     def find_match(value)
-      placeholder_matches.each do |m|
+      @matches.each do |m|
         result = value.scan(m.regexp)
         return m, result.flatten unless result.empty?
       end
-      nil
+
+      #
+      # value is one of the following:
+      #
+      #  %{Jhon Doe}
+      #  %{"Jhon Doe"}
+      #  %{'Jhon Doe'}
+      #
+      # In any case, it passed to the step block in the state without quotes
+      return @default, value.sub(/^(["'])(.*)\1$/, '\2')
     end
 
     def placeholder_matches

--- a/lib/turnip/placeholder.rb
+++ b/lib/turnip/placeholder.rb
@@ -77,7 +77,7 @@ module Turnip
       #  %{'Jhon Doe'}
       #
       # In any case, it passed to the step block in the state without quotes
-      return @default, value.sub(/^(["'])(.*)\1$/, '\2')
+      return @default, value.sub(/^(["'])([^\1]*)\1$/, '\2')
     end
 
     def placeholder_matches

--- a/spec/placeholder_spec.rb
+++ b/spec/placeholder_spec.rb
@@ -94,6 +94,18 @@ describe Turnip::Placeholder do
       expect(placeholder.apply('monkey')).to eq('kn|EY')
       expect(placeholder.apply('bar')).to eq('bar')
     end
+
+    it 'extracts captures by default placeholder and passes to the block' do
+      placeholder = described_class.new(:test) do
+        default do |v|
+          v
+        end
+      end
+
+      expect(placeholder.apply('John Doe')).to eq('John Doe')
+      expect(placeholder.apply('"John Doe"')).to eq('John Doe')
+      expect(placeholder.apply('\'John Doe\'')).to eq('John Doe')
+    end
   end
 
   describe '#regexp' do

--- a/spec/placeholder_spec.rb
+++ b/spec/placeholder_spec.rb
@@ -105,6 +105,9 @@ describe Turnip::Placeholder do
       expect(placeholder.apply('John Doe')).to eq('John Doe')
       expect(placeholder.apply('"John Doe"')).to eq('John Doe')
       expect(placeholder.apply('\'John Doe\'')).to eq('John Doe')
+
+      expect(placeholder.apply('John \n Doe')).to eq('John \n Doe')
+      expect(placeholder.apply('"John \n Doe"')).to eq('John \n Doe')
     end
   end
 


### PR DESCRIPTION
## Problem

https://github.com/jnicklas/turnip/issues/179#issuecomment-218886361

## Cause

`value` to be passed to [Turnip::Placeholder.find_match](https://github.com/jnicklas/turnip/blob/v2.1.0/lib/turnip/placeholder.rb#L66-L72) is one of the following:

```
%{Jhon Doe}
%{"Jhon Doe"}
%{'Jhon Doe'}
```
When run a `String#scan` with [default placeholder regexp](https://github.com/jnicklas/turnip/blob/v2.1.0/lib/turnip/placeholder.rb#L55) against these values:

```
%{Jhon Doe}    =>  ["John", "Doe"]  <= Problem point !
%{"Jhon Doe"}  =>  ["Jhon Doe"]
%{'Jhon Doe'}  =>  ["Jhon Doe"]
```

https://github.com/jnicklas/turnip/issues/179#issuecomment-218886361 is relevant to the first.

## Solution

`value` that did not match the custom placeholder is without scan in regexp of default placeholder, return from remove the quotes, and passed to the step block