### PR TITLE
Add Turnip::Node::Tag#tag_names

### DIFF
--- a/lib/turnip/node/tag.rb
+++ b/lib/turnip/node/tag.rb
@@ -28,6 +28,13 @@ module Turnip
       end
 
       #
+      # @return [Array] Array of tag name
+      #
+      def tag_names
+        tags.map(&:name)
+      end
+
+      #
       # Convert for hash to be used in RSpec
       #
       # @return  [Hash]

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -33,6 +33,16 @@ describe Turnip::Builder do
     end
   end
 
+  context 'with tags' do
+    let(:feature_file) { File.expand_path('../examples/tags.feature', File.dirname(__FILE__)) }
+
+    it 'extracts tags' do
+      expect(feature.tags[0]).to be_instance_of Turnip::Node::Tag
+      expect(feature.scenarios[0].tags[0].name).to eq 'cool'
+      expect(feature.scenarios[1].tag_names).to eq ['stealthy', 'wicked']
+    end
+  end
+
   context "with scenario outlines" do
     let(:feature_file) { File.expand_path('../examples/scenario_outline.feature', File.dirname(__FILE__)) }
 


### PR DESCRIPTION
## Problems

Until [ver 2.1.1] (https://github.com/jnicklas/turnip/blob/v2.1.1/lib/turnip/builder.rb#L6-L8), `tags` method that has been implemented in [Feature](https://github.com/jnicklas/turnip/blob/v2.1.1/lib/turnip/builder.rb#L32), [Scenario](https://github.com/jnicklas/turnip/blob/v2.1.1/lib/turnip/builder.rb#L59) and [ScenarioOutline](https://github.com/jnicklas/turnip/blob/v2.1.1/lib/turnip/builder.rb#L72) returned **Array of tag name**. But, since GH-185, this return **[Array of Turnip::Node::Tag](https://github.com/jnicklas/turnip/blob/v3.0.0.pre.beta.2/lib/turnip/node/tag.rb#L24-L28)** 🙇 

## Solve

New API `tag_names`:

```ruby
scenario.tag_names # => ['foo1', 'foo2']
```