### PR TITLE
fix feature is nil case

### DIFF
--- a/examples/blank.feature
+++ b/examples/blank.feature
@@ -1,0 +1,1 @@
+# no feature file

--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -66,6 +66,8 @@ module Turnip
       def run(feature_file)
         feature = Turnip::Builder.build(feature_file)
 
+        return nil if feature.nil?
+
         instance_eval <<-EOS, feature_file, feature.line
           context = ::RSpec.describe feature.name, feature.metadata_hash
           run_feature(context, feature, feature_file)

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -3,6 +3,15 @@ require 'spec_helper'
 describe Turnip::Builder do
   let(:feature) { Turnip::Builder.build(feature_file) }
 
+  context 'blank file' do
+    let(:feature_file) { File.expand_path('../examples/blank.feature', File.dirname(__FILE__)) }
+
+    it 'has no feature' do
+      feature.should eq nil
+    end
+
+  end
+
   context 'simple scenarios' do
     let(:feature_file) { File.expand_path('../examples/simple_feature.feature', File.dirname(__FILE__)) }
     let(:steps) { feature.scenarios.first.steps }


### PR DESCRIPTION
I found a `nil` case error when I use `v3.0.0.pre.beta.4` in my project.
When turnip loads blank files such as `examples/blank.feature`, then we can see the following error.

```
./lib/turnip/rspec.rb:72:in `run': undefined method `line' for nil:NilClass (NoMethodError)
```

To avoid this error, I insert `return nil` if the feature is nil case.

Could you review this ?