### PR TITLE
Support Ruby 2.2 or higher (Drop 2.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
     - rvm: ruby-head
 
 rvm:
-  - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3
+  - 2.4
   - ruby-head
   - jruby-19mode
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
 
 rvm:
   - 2.2
-  - 2.3
-  - 2.4
+  - 2.3.0
+  - 2.4.0
   - ruby-head
   - jruby-19mode
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ Please create a topic branch for every separate change you make.
 
 ### 1. Ruby
 
-- Support Ruby 2.1 or higher
-- Does not support Ruby 1.9.X and 2.0.X
-- Does not work on Ruby 1.8.X
+- Support Ruby 2.2 or higher
+- Does not support Ruby (or does not work) 2.1.X or earlier
 
 ### 2. RSpec
 


### PR DESCRIPTION
- 🎉 Ruby 2.4.1 Released
    - https://www.ruby-lang.org/en/news/2017/03/22/ruby-2-4-1-released/

- ✋ Support of Ruby 2.1 has ended
    - https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/