### PR TITLE
Allow `steps_for` to dynamically create a module name based on the tag parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,28 @@ Check out [features/alignment_steps.rb](https://github.com/jnicklas/turnip/blob/
 
 for an example.
 
+The `steps_for` method will also define a module based on the tag it is passed. This allows
+you to include a steps_for module in a different steps_for definition.
+
+Example:
+
+``` ruby
+steps_for :interface_steps
+  step "I do interface things" do
+    ...
+  end
+end
+
+steps_for :database_steps
+  include InterfaceSteps
+
+  step "I do database stuff" do
+    ...
+  end
+end
+```
+
+
 ### Where to place steps
 
 Turnip automatically loads your `spec_helper` file. From there you can place

--- a/lib/turnip/dsl.rb
+++ b/lib/turnip/dsl.rb
@@ -15,11 +15,14 @@ module Turnip
         warn "[Turnip] using steps_for(:global) is deprecated, add steps to Turnip::Steps instead"
         Turnip::Steps.module_eval(&block)
       else
-        Module.new do
+        new_module = Module.new do
           singleton_class.send(:define_method, :tag) { tag }
           module_eval(&block)
           ::RSpec.configure { |c| c.include self, tag => true }
         end
+        module_name = tag.to_s.split('_').map(&:capitalize).join + 'Steps'
+
+        Object.const_set(module_name, new_module)
       end
     end
   end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -16,9 +16,17 @@ describe Turnip::DSL do
       an_object.step("foo").should == "foo"
     end
 
+    it 'dynamically creates the module name from the tag' do
+      context.steps_for(:dynamic_foo) do
+        step("foo") { "foo" }
+      end
+
+      defined?(DynamicFooSteps).should == 'constant'
+    end
+
     it 'remembers the name of the module' do
-      mod = context.steps_for(:foo) {}
-      mod.tag.should == :foo
+      mod = context.steps_for(:bar) {}
+      mod.tag.should == :bar
     end
 
     it 'tells RSpec to include the module' do
@@ -26,7 +34,7 @@ describe Turnip::DSL do
       RSpec.should_receive(:configure).and_yield(config)
       config.should_receive(:include)
 
-      context.steps_for(:foo) {}
+      context.steps_for(:foo_bar) {}
     end
 
     it 'warns of deprecation when called with :global' do


### PR DESCRIPTION
My team and I prefer to use `steps_for` over creating a steps file via `module NameHere`. We would also like to include steps from one `steps_for` into another. Right now we have a work around for this. 

```
CoolStepFileSteps = steps_for(:cool_step_file) do 
...
end
```

But this looks a little weird. I created a quick PR to change the behavior of `steps_for` to create a named module based on the tag passed into the method. It concats 'Steps' on the end to prevent name collisions within the main app. It still returns the module. 