### PR TITLE
Add license to gemspec

### DIFF
--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Jonas Nicklas"]
   s.email       = ["jonas.nicklas@gmail.com"]
   s.homepage    = ""
+  s.license     = "MIT"
   s.summary     = %q{Gherkin extension for RSpec}
   s.description = %q{Provides the ability to define steps and run Gherkin files from with RSpec}
 


### PR DESCRIPTION
This PR adds license item to gemspec. This item is used as follows.

- Describing LICENSES on rubygems.org (https://rubygems.org/gems/turnip)
- List of licenses displayed by `bundle licenses` command

This will increase the opportunity for users to learn about license.
