### PR TITLE
Suppress warning

### DIFF
--- a/examples/steps/backtick_steps.rb
+++ b/examples/steps/backtick_steps.rb
@@ -3,7 +3,7 @@ step "I run :cmd" do |cmd|
 end
 
 placeholder :cmd do
-  match /`([^`]*)`/ do |cmd|
+  match (/`([^`]*)`/) do |cmd|
     cmd
   end
 end

--- a/examples/steps/steps.rb
+++ b/examples/steps/steps.rb
@@ -108,13 +108,13 @@ step "raise error" do
 end
 
 placeholder :count do
-  match /\d+/ do |count|
+  match (/\d+/) do |count|
     count.to_i
   end
 end
 
 placeholder :color do
-  match /blue|green|red/ do |color|
+  match (/blue|green|red/) do |color|
     color.to_sym
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -31,7 +31,7 @@ describe Turnip::DSL do
 
     it 'warns of deprecation when called with :global' do
       context.should_receive(:warn)
-      mod = context.steps_for(:global) do
+      context.steps_for(:global) do
         step("foo") { "foo" }
       end
       an_object.extend Turnip::Steps


### PR DESCRIPTION
This PR suppresses the following warning.

``` ruby
ruby -v                                                                                  
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin16]

RUBYOPT=-w bundle exec rake  
turnip/examples/steps/backtick_steps.rb:6: warning: ambiguous first argument; put parentheses or a space even after `/' operator
turnip/examples/steps/steps.rb:111: warning: ambiguous first argument; put parentheses or a space even after `/' operator
turnip/examples/steps/steps.rb:117: warning: ambiguous first argument; put parentheses or a space even after `/' operator

turnip/spec/dsl_spec.rb:34: warning: assigned but unused variable - mod
```