### PR TITLE
Support Ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ branches:
 
 rvm:
   - 2.2
-  - 2.3.5
-  - 2.4.2
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
   - jruby-19mode
 
 gemfile:


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/