### PR TITLE
add minimum Ruby version to gemspec

### DIFF
--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 2.2.0'
+
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
   s.add_runtime_dependency "gherkin", "~> 5.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
This helps dependency resolve. Or is there a reason it isn't there?

If you want, I can also add ruby version requirements to any stable branches.