### PR TITLE
Support RSpec 3.7 and 3.8 (drop 3.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ rvm:
   - jruby-19mode
 
 gemfile:
-  - gemfiles/Gemfile-rspec-3.6.x
   - gemfiles/Gemfile-rspec-3.7.x
+  - gemfiles/Gemfile-rspec-3.8.x

--- a/gemfiles/Gemfile-rspec-3.8.x
+++ b/gemfiles/Gemfile-rspec-3.8.x
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in turnip.gemspec
 gemspec :path => '..'
 
-gem 'rspec', '~> 3.6.0'
+gem 'rspec', '~> 3.8.0'


### PR DESCRIPTION
http://rspec.info/blog/2018/08/rspec-3-8-has-been-released/

I was late 😭 

See: RSpec support policy https://github.com/jnicklas/turnip/issues/158#issuecomment-119049054