### PR TITLE
Support Gherkin 6 (without `Rule` keyword)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.3
-  - jruby-19mode
+  - jruby
 
 gemfile:
   - gemfiles/Gemfile-rspec-3.7.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ branches:
   only:
     - master
 
+#
+# Ignore JRuby until https://github.com/cucumber/cucumber/pull/486 is merged
+#
+matrix:
+  allow_failures:
+  - rvm: jruby
+
 rvm:
   - 2.3.6
   - 2.4.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-#
-# Pick a known-good version when running builds for cucumber-messages on JRuby.
-#
-# see: https://github.com/cucumber/cucumber/pull/486
-#
-platforms :jruby do
-  gem 'google-protobuf', '~> 3.2.0.2'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,12 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in turnip.gemspec
 gemspec
+
+#
+# Pick a known-good version when running builds for cucumber-messages on JRuby.
+#
+# see: https://github.com/cucumber/cucumber/pull/486
+#
+platforms :jruby do
+  gem 'google-protobuf', '~> 3.2.0.2'
+end

--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -1,13 +1,13 @@
-require "gherkin/parser"
+require "gherkin/gherkin"
 require 'turnip/node/feature'
 
 module Turnip
   class Builder
     def self.build(feature_file)
-      parser = Gherkin::Parser.new
-      result = parser.parse(File.read(feature_file))
+      messages = Gherkin::Gherkin.from_paths([feature_file], include_source: false, include_pickles: false)
+      result = messages.first&.gherkinDocument&.to_hash
 
-      return nil unless result[:feature]
+      return nil if result.nil? || result[:feature].nil?
       Node::Feature.new(result[:feature])
     end
   end

--- a/lib/turnip/node/example.rb
+++ b/lib/turnip/node/example.rb
@@ -42,7 +42,7 @@ module Turnip
       # @return [Array]
       #
       def header
-        @header ||= @raw[:tableHeader][:cells].map { |c| c[:value] }
+        @header ||= @raw[:table_header][:cells].map { |c| c[:value] }
       end
 
       #
@@ -56,7 +56,7 @@ module Turnip
       # @return [Array]
       #
       def rows
-        @rows ||= @raw[:tableBody].map do |row|
+        @rows ||= @raw[:table_body].map do |row|
           row[:cells].map { |c| c[:value] }
         end
       end

--- a/lib/turnip/node/feature.rb
+++ b/lib/turnip/node/feature.rb
@@ -40,16 +40,28 @@ module Turnip
       end
 
       def children
-        @children ||= @raw[:children].map do |c|
-          case c[:type]
-          when :Background
-            Background.new(c)
-          when :Scenario
-            Scenario.new(c)
-          when :ScenarioOutline
-            ScenarioOutline.new(c)
-          end
-        end.compact
+        @children ||= @raw[:children].map do |child|
+          #
+          # @TODO
+          #
+          #   rule = unless child[:rule].nil?
+          #            Rule.new(child[:rule])
+          #          end
+          #
+          background = unless child[:background].nil?
+                         Background.new(child[:background])
+                       end
+
+          scenario = unless child[:scenario].nil?
+                       if child[:scenario][:examples].empty?
+                         Scenario.new(child[:scenario])
+                       else
+                         ScenarioOutline.new(child[:scenario])
+                       end
+                     end
+
+          [background, scenario]
+        end.flatten.compact
       end
 
       def backgrounds

--- a/lib/turnip/node/scenario_outline.rb
+++ b/lib/turnip/node/scenario_outline.rb
@@ -65,13 +65,11 @@ module Turnip
             metadata[:steps].each do |step|
               step[:text] = substitute(step[:text], header, row)
 
-              next if step[:argument].nil?
-
-              case step[:argument][:type]
-              when :DocString
-                step[:argument][:content] = substitute(step[:argument][:content], header, row)
-              when :DataTable
-                step[:argument][:rows].map do |table_row|
+              case
+              when step[:doc_string]
+                step[:doc_string][:content] = substitute(step[:doc_string][:content], header, row)
+              when step[:data_table]
+                step[:data_table][:rows].map do |table_row|
                   table_row[:cells].map do |cell|
                     cell[:value] = substitute(cell[:value], header, row)
                   end

--- a/lib/turnip/node/step.rb
+++ b/lib/turnip/node/step.rb
@@ -31,13 +31,11 @@ module Turnip
       end
 
       def argument
-        return nil if @raw[:argument].nil?
-
-        @argument ||= case @raw[:argument][:type]
-                      when :DocString
-                        doc_string(@raw[:argument])
-                      when :DataTable
-                        data_table(@raw[:argument])
+        @argument ||= case
+                      when @raw[:doc_string]
+                        doc_string(@raw[:doc_string])
+                      when @raw[:data_table]
+                        data_table(@raw[:data_table])
                       end
       end
 

--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "gherkin", "~> 6.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
-  s.add_development_dependency "pry-byebug"
 end

--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
-  s.add_runtime_dependency "gherkin", "~> 5.0"
+  s.add_runtime_dependency "gherkin", "~> 6.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
+  s.add_development_dependency "pry-byebug"
 end


### PR DESCRIPTION
## 🍕 Motivation

https://github.com/jnicklas/turnip/issues/205

## 💪 Did

- Update gherkin version

    > The library API however is not backwards compatible. It is now a stream-like API which produces a stream of messages (source, AST and pickle messages).
    >
    > [cucumber/CHANGELOG\.md at master · cucumber/cucumber](https://github.com/cucumber/cucumber/blob/master/gherkin/CHANGELOG.md#6013---2018-09-25)

## 🙅‍♂️ Did not (now)

Support for new `Rule` keyword that has been introduced in 6.0.
At a later date, I will respond it with another Pull Request.

## 👀 References

- [Rules \+ Examples · Issue \#250 · cucumber/cucumber](https://github.com/cucumber/cucumber/issues/250)
- [6.0.13 - 2018-09-25 cucumber/CHANGELOG\.md at master · cucumber/cucumber](https://github.com/cucumber/cucumber/blob/master/gherkin/CHANGELOG.md#6013---2018-09-25)
- [Use gherkin 6 by brasmusson · Pull Request \#1313 · cucumber/cucumber\-ruby](https://github.com/cucumber/cucumber-ruby/pull/1313)