### PR TITLE
Run travis ci on ruby 2.6.0 although currently failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,15 @@ branches:
 #
 matrix:
   allow_failures:
-  - rvm: jruby
+  - rvm:
+    - jruby
+    - 2.6.0
 
 rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.3
+  - 2.6.0
   - jruby
 
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ branches:
 #
 matrix:
   allow_failures:
-  - rvm:
-    - jruby
-    - 2.6.0
+  - rvm: jruby
+  - rvm: 2.6.0
 
 rvm:
   - 2.3.6


### PR DESCRIPTION
Currently running tests on Ruby 2.6 fails, because `google-protobuf` current release does not support 2.6 and we should wait for next release.

https://github.com/protocolbuffers/protobuf/issues/5161