### PR TITLE
add required_ruby_version

### DIFF
--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -3,6 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 require "turnip/version"
 
 Gem::Specification.new do |s|
+  s.required_ruby_version = ">= 2.3"
   s.name        = "turnip"
   s.version     = Turnip::VERSION
   s.authors     = ["Jonas Nicklas"]


### PR DESCRIPTION
What about adding `required_ruby_version` in order to restrict target Ruby version?
https://guides.rubygems.org/specification-reference/#required_ruby_version=

e.g.

```
XXX requires ruby version >= 2.3.0, which is incompatible with the current version, ruby 2.2.2p95
```