### PR TITLE
Add support ruby2.6 by upgrading Gherkin version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ branches:
 matrix:
   allow_failures:
   - rvm: jruby
-  - rvm: 2.6.0
 
 rvm:
   - 2.3.6

--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
-  s.add_runtime_dependency "gherkin", "~> 6.0"
+  s.add_runtime_dependency "gherkin", "~> 6.0.17"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This is continuation of this PR https://github.com/jnicklas/turnip/pull/207

Recent gherkin / cucumber-message / google-protobuf  release solved issue with ruby 2.6
https://github.com/cucumber/cucumber/pull/578

After updating gherkin version, tests are passed with ruby 2.6