### PR TITLE
Warn when replacing placeholders

### DIFF
--- a/lib/turnip/placeholder.rb
+++ b/lib/turnip/placeholder.rb
@@ -4,6 +4,11 @@ module Turnip
 
     class << self
       def add(name, &block)
+        if placeholders.key?(name)
+          location = caller_locations.detect { |l| l.to_s !~ /lib\/turnip\/dsl\.rb/ }
+          warn "Placeholder :#{name} was replaced at #{location}."
+        end
+
         placeholders[name] = Placeholder.new(name, &block)
       end
 

--- a/spec/placeholder_spec.rb
+++ b/spec/placeholder_spec.rb
@@ -9,6 +9,8 @@ describe Turnip::Placeholder do
       end
     end
 
+    after { Turnip::Placeholder.send(:placeholders).clear }
+
     it 'returns a regexp for the given placeholder' do
       resolved = described_class.resolve(:test)
 
@@ -147,6 +149,21 @@ describe Turnip::Placeholder do
 
       it 'should not multiple incorrect fragments' do
         expect('bar').not_to match(placeholder.regexp)
+      end
+    end
+  end
+
+  describe 'replacing placeholders' do
+    before do
+      described_class.add(:test) do
+        match(/foo/)
+      end
+    end
+
+    it 'issues a warning' do
+      expect(described_class).to receive(:warn).with(/Placeholder :test was replaced/)
+      described_class.add(:test) do
+        match(/bar/)
       end
     end
   end

--- a/spec/step_definition_spec.rb
+++ b/spec/step_definition_spec.rb
@@ -3,6 +3,8 @@ require "spec_helper"
 describe Turnip::StepDefinition do
   let(:all_steps) { [] }
 
+  after { Turnip::Placeholder.send(:placeholders).clear }
+
   describe "#match" do
     it "matches a simple step" do
       step = Turnip::StepDefinition.new("there are monsters") {}


### PR DESCRIPTION
This PR addresses an issue we've faced with a large Turnip codebase using placeholders with generic names like `:object` in multiple helpers across multiple files. This led to the placeholders being easily overridden and producing obscure and hard to track down bugs in our test suite.

The main change is to issue a warning that a a placeholder is being replaced if there's already a non-default placeholder. The warning includes the file and line using `caller_locations` which is supported in Ruby 2.2 onwards.

With just this change the Turnip test suite now issues warnings as it runs as it relies on replacing placeholders being silent. To address this I've added a `.clear` convenience method which removes all the added placeholders reverting them to the original default.