### PR TITLE
Upgrade cucumber-gherkin to v10

### DIFF
--- a/lib/turnip/node/feature.rb
+++ b/lib/turnip/node/feature.rb
@@ -33,7 +33,7 @@ module Turnip
           end
 
           unless child[:scenario].nil?
-            klass = child[:scenario][:examples].empty? ? Scenario : ScenarioOutline
+            klass = child[:scenario][:examples].blank? ? Scenario : ScenarioOutline
             next klass.new(child[:scenario])
           end
 

--- a/lib/turnip/node/feature.rb
+++ b/lib/turnip/node/feature.rb
@@ -33,7 +33,7 @@ module Turnip
           end
 
           unless child[:scenario].nil?
-            klass = child[:scenario][:examples].blank? ? Scenario : ScenarioOutline
+            klass = child.dig(:scenario, :examples).nil? ? Scenario : ScenarioOutline
             next klass.new(child[:scenario])
           end
 

--- a/lib/turnip/node/rule.rb
+++ b/lib/turnip/node/rule.rb
@@ -22,7 +22,7 @@ module Turnip
           end
 
           unless child[:scenario].nil?
-            klass = child[:scenario][:examples].blank? ? Scenario : ScenarioOutline
+            klass = child.dig(:scenario, :examples).nil? ? Scenario : ScenarioOutline
             next klass.new(child[:scenario])
           end
         end.compact

--- a/lib/turnip/node/rule.rb
+++ b/lib/turnip/node/rule.rb
@@ -22,7 +22,7 @@ module Turnip
           end
 
           unless child[:scenario].nil?
-            klass = child[:scenario][:examples].empty? ? Scenario : ScenarioOutline
+            klass = child[:scenario][:examples].blank? ? Scenario : ScenarioOutline
             next klass.new(child[:scenario])
           end
         end.compact

--- a/lib/turnip/node/tag.rb
+++ b/lib/turnip/node/tag.rb
@@ -22,7 +22,7 @@ module Turnip
       # @return [Array] Array of Tag
       #
       def tags
-        @tags ||= (@raw[:tags].blank? ? [] : @raw[:tags]).map do |tag|
+        @tags ||= @raw.fetch(:tags, []).map do |tag|
           Tag.new(tag)
         end
       end

--- a/lib/turnip/node/tag.rb
+++ b/lib/turnip/node/tag.rb
@@ -22,7 +22,7 @@ module Turnip
       # @return [Array] Array of Tag
       #
       def tags
-        @tags ||= @raw[:tags].map do |tag|
+        @tags ||= (@raw[:tags].blank? ? [] : @raw[:tags]).map do |tag|
           Tag.new(tag)
         end
       end

--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -13,15 +13,13 @@ Gem::Specification.new do |s|
   s.summary     = %q{Gherkin extension for RSpec}
   s.description = %q{Provides the ability to define steps and run Gherkin files from with RSpec}
 
-  s.rubyforge_project = "turnip"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
-  s.add_runtime_dependency "gherkin", "~> 9.0"
+  s.add_runtime_dependency "cucumber-gherkin", "~> 10.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Gherkin has changed it's name to cucumber-gherkin ( https://rubygems.org/gems/cucumber-gherkin ), so this bumps the version and uses the new name.

Fixes to the expected metadata from Gherkin. Tags & Examples are now optional, so .blank? is used to test, where .empty? breaks on nil

Removed link to rubyforge_project in the gemspec, because it's deprecated.

:pear: @jayzz55