### PR TITLE
Improve documentation formatter to show each step on a new line

### DIFF
--- a/examples/documentation_formatter.feature
+++ b/examples/documentation_formatter.feature
@@ -1,0 +1,17 @@
+Feature: Documentation formatter examples
+  Scenario: Passing
+    Given there is a monster
+    When I attack it
+    Then it should die
+
+  Scenario: Error
+    Given there is a monster
+    When I attack it
+    And raise error
+    Then it should die
+
+  Scenario: Pending
+    Given there is a monster
+    When I attack it
+    And do something unexpected
+    Then it should die

--- a/lib/turnip.rb
+++ b/lib/turnip.rb
@@ -6,6 +6,7 @@ require "turnip/builder"
 require "turnip/step_definition"
 require "turnip/placeholder"
 require "turnip/table"
+require "turnip/documentation_formatter_extensions"
 
 module Turnip
   class Pending < StandardError; end

--- a/lib/turnip/documentation_formatter_extensions.rb
+++ b/lib/turnip/documentation_formatter_extensions.rb
@@ -1,7 +1,5 @@
 module Turnip
   module DocumentationFormatterExtensions
-    RSpec::Core::Formatters.register self, :example_started, :step_started, :step_passed
-
     def initialize(output)
       super
 
@@ -85,20 +83,27 @@ module Turnip
   end
 end
 
-class ::RSpec::Core::Formatters::DocumentationFormatter
-  prepend Turnip::DocumentationFormatterExtensions
-end
+# Only extend documentation formatter if it's loaded
+if defined?(RSpec::Core::Formatters::DocumentationFormatter)
+  module Turnip::DocumentationFormatterExtensions
+    RSpec::Core::Formatters.register self, :example_started, :step_started, :step_passed
+  end
 
-class RSpec::Core::Formatters::ExceptionPresenter
-  def encoded_description(description)
-    return if description.nil?
+  class ::RSpec::Core::Formatters::DocumentationFormatter
+    prepend Turnip::DocumentationFormatterExtensions
+  end
 
-    if example.metadata[:turnip] && example.metadata[:failed_step]
-      step = example.metadata[:failed_step].to_s
-      error = ::RSpec::Core::Formatters::ConsoleCodes.wrap(step, :failure)
-      description = description.gsub(step, error)
+  class RSpec::Core::Formatters::ExceptionPresenter
+    def encoded_description(description)
+      return if description.nil?
+
+      if example.metadata[:turnip] && example.metadata[:failed_step]
+        step = example.metadata[:failed_step].to_s
+        error = ::RSpec::Core::Formatters::ConsoleCodes.wrap(step, :failure)
+        description = description.gsub(step, error)
+      end
+
+      encoded_string(description)
     end
-
-    encoded_string(description)
   end
 end

--- a/lib/turnip/documentation_formatter_extensions.rb
+++ b/lib/turnip/documentation_formatter_extensions.rb
@@ -1,0 +1,104 @@
+module Turnip
+  module DocumentationFormatterExtensions
+    RSpec::Core::Formatters.register self, :example_started, :step_started, :step_passed
+
+    def initialize(output)
+      super
+
+      @current_step = nil
+      @remaining_scenario_steps = []
+    end
+
+    def example_started(notification)
+      super if defined?(super)
+
+      @remaining_scenario_steps = notification.example.metadata[:turnip_steps].dup
+    end
+
+    def step_started(notification)
+      @current_step = notification.step
+      @remaining_scenario_steps.shift
+    end
+
+    def step_passed(notification)
+      output.puts step_passed_output(notification.step)
+    end
+
+    def example_passed(passed)
+      return super unless turnip_example?(passed)
+
+      flush_messages if respond_to? :flush_messages
+      @example_running = false
+    end
+
+    def example_pending(pending)
+      return super unless turnip_example?(pending)
+
+      output.puts step_pending_output(@current_step,
+                                      pending.example.execution_result.pending_message)
+      output.puts remaining_step_names
+
+      flush_messages if respond_to? :flush_messages
+      @example_running = false
+    end
+
+    def example_failed(failure)
+      return super unless turnip_example?(failure)
+
+      failure.example.metadata[:failed_step] = @current_step
+      output.puts step_failed_output(@current_step)
+      output.puts remaining_step_names
+
+      flush_messages if respond_to? :flush_messages
+      @example_running = false
+    end
+
+    private
+
+      def turnip_example?(notification)
+        notification.example.metadata[:turnip]
+      end
+
+      def step_passed_output(step)
+        ::RSpec::Core::Formatters::ConsoleCodes.wrap("#{current_indentation}#{step}",
+                                                     :success)
+      end
+
+      def step_pending_output(step, message)
+        ::RSpec::Core::Formatters::ConsoleCodes.wrap("#{current_indentation}#{step} " \
+                                                     "(PENDING: #{message})",
+                                                     :pending)
+      end
+
+      def step_failed_output(step)
+        ::RSpec::Core::Formatters::ConsoleCodes.wrap("#{current_indentation}#{step} " \
+                                                     "(FAILED - #{next_failure_index})",
+                                                     :failure)
+      end
+
+      def remaining_step_names
+        @remaining_scenario_steps.map do |step|
+          ::RSpec::Core::Formatters::ConsoleCodes.wrap("#{current_indentation}#{step}",
+                                                       :default)
+        end
+      end
+  end
+end
+
+class ::RSpec::Core::Formatters::DocumentationFormatter
+  prepend Turnip::DocumentationFormatterExtensions
+end
+
+class RSpec::Core::Formatters::ExceptionPresenter
+  def encoded_description(description)
+    return if description.nil?
+
+    if example.metadata[:turnip] && example.metadata[:failed_step]
+      step = example.metadata[:failed_step].to_s
+      error = ::RSpec::Core::Formatters::ConsoleCodes.wrap(step, :failure)
+      description = description.gsub(step, error)
+    end
+
+    encoded_string(description)
+  end
+end

--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -40,11 +40,16 @@ module Turnip
       include Turnip::Execute
 
       def run_step(feature_file, step)
+        reporter = ::RSpec.current_example.reporter
+        reporter.publish(:step_started, { step: step })
+
         begin
           instance_eval <<-EOS, feature_file, step.line
             step(step)
           EOS
         rescue Turnip::Pending => e
+          reporter.publish(:step_pending, { step: step })
+
           example = ::RSpec.current_example
           example.metadata[:line_number] = step.line
           example.metadata[:location] = "#{example.metadata[:file_path]}:#{step.line}"
@@ -56,9 +61,13 @@ module Turnip
 
           skip("No such step: '#{e}'")
         rescue StandardError, ::RSpec::Expectations::ExpectationNotMetError => e
+          reporter.publish(:step_failed, { step: step })
+
           e.backtrace.push "#{feature_file}:#{step.line}:in `#{step.description}'"
           raise e
         end
+
+        reporter.publish(:step_passed, { step: step })
       end
     end
 
@@ -91,10 +100,11 @@ module Turnip
         end
 
         group.scenarios.each do |scenario|
-          step_names = (background_steps + scenario.steps).map(&:to_s)
-          description = step_names.join(' -> ')
+          all_steps = background_steps + scenario.steps
+          description = all_steps.map(&:to_s).join(' -> ')
+          metadata = scenario.metadata_hash.merge(turnip_steps: all_steps)
 
-          context.describe scenario.name, scenario.metadata_hash do
+          context.describe scenario.name, metadata do
             instance_eval <<-EOS, filename, scenario.line
               it description do
                 scenario.steps.each do |step|

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -8,11 +8,11 @@ describe 'The CLI', :type => :integration do
   it "shows the correct description" do
     @result.should include('A simple feature')
     @result.should include('This is a simple feature')
-    @result.should include('Given there is a monster -> When I attack it -> Then it should die')
+    @result.should match /Given there is a monster\n\s*When I attack it\n\s*Then it should die/
   end
 
   it "prints out failures and successes" do
-    @result.should include('42 examples, 4 failures, 5 pending')
+    @result.should include('45 examples, 5 failures, 6 pending')
   end
 
   it "includes features in backtraces" do
@@ -39,5 +39,10 @@ describe 'The CLI', :type => :integration do
     result_with_line_number.should include('rspec ./examples/errors.feature:4')
     result_with_line_number.should_not include('rspec ./examples/errors.feature:6')
     result_with_line_number.should_not include('rspec ./examples/errors.feature:11')
+  end
+
+  it 'prints remaining steps after failure or pending' do
+    @result.should match /And raise error \(FAILED.*\n\s*Then it should die/
+    @result.should match /And do something unexpected \(PENDING.*\n\s*Then it should die/
   end
 end


### PR DESCRIPTION
When debugging failed tests, I like to run rspec with `--format documentation` to see as much info as possible when running tests. While using Turnip I was missing a way to see exactly which step failed.

So I created a new formatter based on the default RSpec documentation formatter to show each step on it's own line.

**Before:**
![turnip_documentation_formatter_before](https://user-images.githubusercontent.com/242972/81500490-bab41780-92fc-11ea-8a31-94bfe982c45c.png)

**After:**
![turnip_documentation_formatter](https://user-images.githubusercontent.com/242972/81497557-779c7900-92e9-11ea-919f-d4d714540267.png)

The most obvious change is that each step is now on it's own line. This is to see in exactly which step an error occurs.

At the bottom where all failures are listed the actual step where the error occured is highlighted again, as a quick reminder.

Any examples not using Turnip will still use the default documentation style.

Some remarks:

- I chose to extend the existing documentation formatter instead of creating a new class for it. This means that everyone using the default documentation formatter will get the new formatter without any work on their part.
  
  Is changing the default documentation output okay? I could see some people preferring the old style. If so, we should make this a new formatter that people will have to manually enable instead.

- Highlighting the error step in the failures listing is done by name. This means if 2 steps have the same name and 1 has an error, both steps will be highlighted.
  
  I tried adding a "<!>" before the step name to indicate the failed step, but that wasn't very clear. And I tried adding a new line below the description that said: "Error in step: And raise error", but I preferred highlight the actual step instead.
