### PR TITLE
Suppress deprecation warning in Capybara 3.33.0

### DIFF
--- a/lib/turnip/capybara.rb
+++ b/lib/turnip/capybara.rb
@@ -7,7 +7,8 @@ RSpec.configure do |config|
     if self.class.include?(Capybara::DSL) and current_example.metadata[:turnip]
       Capybara.current_driver = Capybara.javascript_driver if current_example.metadata.has_key?(:javascript)
       current_example.metadata.each do |tag, value|
-        if Capybara.drivers.has_key?(tag)
+        has_driver = Capybara::VERSION >= '3.33.0' ? !Capybara.drivers[tag].nil? : Capybara.drivers.has_key?(tag)
+        if has_driver
           Capybara.current_driver = tag
         end
       end


### PR DESCRIPTION
Capybara >= 3.33.0 deprecated direct manipulation of the driver
and server registries. 

https://github.com/teamcapybara/capybara/commit/6fcd43aec8db49184a28f05ab6fbc20670911dee

( @capytan has already described on #230 , thank you )

fix #230