### PR TITLE
Support scenario name substitution

### DIFF
--- a/examples/scenario_outline_scenario_name_substitution.feature
+++ b/examples/scenario_outline_scenario_name_substitution.feature
@@ -1,0 +1,13 @@
+Feature: using scenario outlines
+  Scenario Outline: a monster introduced himself as <name>
+    Given there is a monster called <name>
+    Then the monster introduced himself:
+      """
+      Ahhhhhhh! i'm <name>!
+      """
+
+    Examples:
+      | name          |
+      | John          |
+      | "John Smith"  |
+      | "O'Flannahan" |

--- a/lib/turnip/node/scenario_outline.rb
+++ b/lib/turnip/node/scenario_outline.rb
@@ -57,7 +57,7 @@ module Turnip
           header = example.header
 
           example.rows.map do |row|
-            metadata = convert_metadata_to_scenario
+            metadata = convert_metadata_to_scenario(header, row)
 
             #
             # Replace <placeholder> using Example values
@@ -115,10 +115,11 @@ module Turnip
       # @todo :keyword is not considered a language (en only)
       # @return  [Hash]
       #
-      def convert_metadata_to_scenario()
+      def convert_metadata_to_scenario(header, row)
         # deep copy
         Marshal.load(Marshal.dump(raw)).tap do |new_raw|
           new_raw.delete(:examples)
+          new_raw[:name] = substitute(new_raw[:name], header, row)
           new_raw[:type] = :Scenario
           new_raw[:keyword] = 'Scenario'
         end

--- a/spec/builder_spec.rb
+++ b/spec/builder_spec.rb
@@ -75,6 +75,18 @@ describe Turnip::Builder do
     end
   end
 
+  context "with example scenario name in scenario outlines" do
+    let(:feature_file) { File.expand_path('../examples/scenario_outline_scenario_name_substitution.feature', File.dirname(__FILE__)) }
+
+    it "replaces placeholders in scenario name" do
+      feature.scenarios.map(&:name).should eq([
+        "a monster introduced himself as John",
+        'a monster introduced himself as "John Smith"',
+        %(a monster introduced himself as "O'Flannahan")
+      ])
+    end
+  end
+
   context "with example tables in scenario outlines" do
     let(:feature_file) { File.expand_path('../examples/scenario_outline_table_substitution.feature', File.dirname(__FILE__)) }
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -12,7 +12,7 @@ describe 'The CLI', :type => :integration do
   end
 
   it "prints out failures and successes" do
-    @result.should include('42 examples, 4 failures, 5 pending')
+    @result.should include('45 examples, 4 failures, 5 pending')
   end
 
   it "includes features in backtraces" do


### PR DESCRIPTION
Support scenario name substitution is convenient to identifying which example is failed.

It is useful when writing scenario outline like following:

```gherkin
Scenario Outline: <Role> delete other user's item
  When <Role> logged in
  Then ...

  Examples:
    | Role     |
    | Admin    |
    | Operator |
```