### PR TITLE
Support RSpec 3.9 and 3.10 (drop 3.7 and 3.8)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,8 @@ jobs:
           - '2.7'
           - jruby
         gemfiles:
-          - gemfiles/Gemfile-rspec-3.7.x
-          - gemfiles/Gemfile-rspec-3.8.x
           - gemfiles/Gemfile-rspec-3.9.x
+          - gemfiles/Gemfile-rspec-3.10.x
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,5 @@ rvm:
   - jruby
 
 gemfile:
-  - gemfiles/Gemfile-rspec-3.7.x
-  - gemfiles/Gemfile-rspec-3.8.x
   - gemfiles/Gemfile-rspec-3.9.x
+  - gemfiles/Gemfile-rspec-3.10.x

--- a/gemfiles/Gemfile-rspec-3.10.x
+++ b/gemfiles/Gemfile-rspec-3.10.x
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in turnip.gemspec
 gemspec :path => '..'
 
-gem 'rspec', '~> 3.8.0'
+gem 'rspec', '~> 3.10.0'
 gem 'pry-byebug', platforms: :mri

--- a/gemfiles/Gemfile-rspec-3.7.x
+++ b/gemfiles/Gemfile-rspec-3.7.x
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-# Specify your gem's dependencies in turnip.gemspec
-gemspec :path => '..'
-
-gem 'rspec', '~> 3.7.0'
-gem 'pry-byebug', platforms: :mri


### PR DESCRIPTION
https://github.com/rspec/rspec-core/blob/main/Changelog.md#3100--2020-10-30

I was late 😭

See: RSpec support policy https://github.com/jnicklas/turnip/issues/158#issuecomment-119049054