### PR TITLE
Upgrade cucumber-gherkin to version 22

### DIFF
--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -10,7 +10,7 @@ module Turnip
         include_gherkin_document: true,
         include_pickles: false
       )
-      result = messages.first&.gherkin_document&.to_hash
+      result = messages.first&.gherkin_document&.to_h
 
       return nil if result.nil? || result[:feature].nil?
       Node::Feature.new(result[:feature])

--- a/lib/turnip/node/feature.rb
+++ b/lib/turnip/node/feature.rb
@@ -33,7 +33,7 @@ module Turnip
           end
 
           unless child[:scenario].nil?
-            klass = child.dig(:scenario, :examples).nil? ? Scenario : ScenarioOutline
+            klass = child.dig(:scenario, :examples).empty? ? Scenario : ScenarioOutline
             next klass.new(child[:scenario])
           end
 

--- a/lib/turnip/node/rule.rb
+++ b/lib/turnip/node/rule.rb
@@ -22,7 +22,7 @@ module Turnip
           end
 
           unless child[:scenario].nil?
-            klass = child.dig(:scenario, :examples).nil? ? Scenario : ScenarioOutline
+            klass = child.dig(:scenario, :examples).empty? ? Scenario : ScenarioOutline
             next klass.new(child[:scenario])
           end
         end.compact

--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
-  s.add_runtime_dependency "cucumber-gherkin", "~> 14.0"
+  s.add_runtime_dependency "cucumber-gherkin", "~> 22.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Hi 👋 

This PR updates the `cucumber-gherkin` dependency in the Turnip gemspec to v22 from v14.  The reason for this was a selfish one. 😄  

Our app is currently using Turnip v4.3.0, which has the following dependency tree:
```
Turnip v4.3.0
  -> cucumber-gherkin ~> 14.0
       -> cucumber-messages ~> 12.4, >= 12.4.0
            ->  protobuf-cucumber ~> 3.10, >= 3.10.8
```

I was attempting to add another gem, which depends on `google-protobuf = 3.18.0`, but this caused a conflict with the `protobuf-cucumber` gem that manifested in this error message:

```
protobuf-cucumber-3.10.8/lib/protobuf/descriptors/google/protobuf/descriptor.pb.rb:15:in `<module:Protobuf>': superclass mismatch for class FileDescriptorSet (TypeError)
```

Since `cucumber-messages >= 16.0.0` no longer depends on `protobuf-cucumber` I figured that upgrading this dependency was the easiest path towards resolving this conflict.

I have run the project tests against this PR locally and they all pass.  I also added my fork to our app and everything seems to be working well with that as well FWIW.

Please let me know if there is any other testing that needs to be done or added and I will add that to this PR.

Thanks,
Jason