### PR TITLE
Add Gherkin abstraction layer

### DIFF
--- a/examples/specific_language.feature
+++ b/examples/specific_language.feature
@@ -1,0 +1,5 @@
+# language: en-au
+
+Pretty much: A feature that specifies a language
+  Awww, look mate: This is a language specific feature
+    * a step

--- a/lib/turnip/builder.rb
+++ b/lib/turnip/builder.rb
@@ -1,19 +1,13 @@
-require "gherkin"
+require "cuke_modeler"
 require 'turnip/node/feature'
 
 module Turnip
   class Builder
     def self.build(feature_file)
-      messages = Gherkin.from_paths(
-        [feature_file],
-        include_source: false,
-        include_gherkin_document: true,
-        include_pickles: false
-      )
-      result = messages.first&.gherkin_document&.to_hash
+      feature_file = CukeModeler::FeatureFile.new(feature_file)
 
-      return nil if result.nil? || result[:feature].nil?
-      Node::Feature.new(result[:feature])
+      return nil unless feature_file.feature
+      Node::Feature.new(feature_file.feature)
     end
   end
 end

--- a/lib/turnip/node/example.rb
+++ b/lib/turnip/node/example.rb
@@ -42,7 +42,7 @@ module Turnip
       # @return [Array]
       #
       def header
-        @header ||= @raw[:table_header][:cells].map { |c| c[:value] }
+        @header ||= @raw.parameter_row.cells.map { |c| c.value }
       end
 
       #
@@ -56,8 +56,8 @@ module Turnip
       # @return [Array]
       #
       def rows
-        @rows ||= @raw[:table_body].map do |row|
-          row[:cells].map { |c| c[:value] }
+        @rows ||= @raw.argument_rows.map do |row|
+          row.cells.map { |c| c.value }
         end
       end
     end

--- a/lib/turnip/node/example.rb
+++ b/lib/turnip/node/example.rb
@@ -20,15 +20,15 @@ module Turnip
       include HasTags
 
       def keyword
-        @raw[:keyword]
+        @raw.keyword
       end
 
       def name
-        @raw[:name]
+        @raw.name
       end
 
       def description
-        @raw[:description]
+        @raw.description
       end
 
       #

--- a/lib/turnip/node/feature.rb
+++ b/lib/turnip/node/feature.rb
@@ -27,18 +27,21 @@ module Turnip
       end
 
       def children
-        @children ||= @raw[:children].map do |child|
-          unless child[:background].nil?
-            next Background.new(child[:background])
+        @children ||= @raw.children.map do |child|
+          if child.is_a?(CukeModeler::Background)
+            next Background.new(child)
           end
 
-          unless child[:scenario].nil?
-            klass = child.dig(:scenario, :examples).nil? ? Scenario : ScenarioOutline
-            next klass.new(child[:scenario])
+          if child.is_a?(CukeModeler::Scenario)
+            next Scenario.new(child)
           end
 
-          unless child[:rule].nil?
-            next Rule.new(child[:rule])
+          if child.is_a?(CukeModeler::Outline)
+            next ScenarioOutline.new(child)
+          end
+
+          if child.is_a?(CukeModeler::Rule)
+            next Rule.new(child)
           end
         end.compact
       end

--- a/lib/turnip/node/feature.rb
+++ b/lib/turnip/node/feature.rb
@@ -23,7 +23,7 @@ module Turnip
       include HasTags
 
       def language
-        @raw.parsing_data.language
+        @raw.language
       end
 
       def children

--- a/lib/turnip/node/feature.rb
+++ b/lib/turnip/node/feature.rb
@@ -23,7 +23,7 @@ module Turnip
       include HasTags
 
       def language
-        @raw[:language]
+        @raw.parsing_data.language
       end
 
       def children

--- a/lib/turnip/node/location.rb
+++ b/lib/turnip/node/location.rb
@@ -23,7 +23,17 @@ module Turnip
       # @return [Location]
       #
       def location
-        @location ||= Location.new(@raw[:location][:line], @raw[:location][:column])
+        # TODO: Update CukeModeler so that it models the column as well as the line. That way accessing the raw data can be avoided.
+        case
+          when raw.is_a?(CukeModeler::Background)
+            @location ||= Location.new(@raw.parsing_data.background.location.line, @raw.parsing_data.background.location.column)
+          when raw.is_a?(CukeModeler::Rule)
+            @location ||= Location.new(@raw.parsing_data.rule.location.line, @raw.parsing_data.rule.location.column)
+          when raw.is_a?(CukeModeler::Scenario) || raw.is_a?(CukeModeler::Outline)
+            @location ||= Location.new(@raw.parsing_data.scenario.location.line, @raw.parsing_data.scenario.location.column)
+          else
+            @location ||= Location.new(@raw.parsing_data.location.line, @raw.parsing_data.location.column)
+        end
       end
 
       def line

--- a/lib/turnip/node/location.rb
+++ b/lib/turnip/node/location.rb
@@ -23,17 +23,7 @@ module Turnip
       # @return [Location]
       #
       def location
-        # TODO: Update CukeModeler so that it models the column as well as the line. That way accessing the raw data can be avoided.
-        case
-          when raw.is_a?(CukeModeler::Background)
-            @location ||= Location.new(@raw.parsing_data.background.location.line, @raw.parsing_data.background.location.column)
-          when raw.is_a?(CukeModeler::Rule)
-            @location ||= Location.new(@raw.parsing_data.rule.location.line, @raw.parsing_data.rule.location.column)
-          when raw.is_a?(CukeModeler::Scenario) || raw.is_a?(CukeModeler::Outline)
-            @location ||= Location.new(@raw.parsing_data.scenario.location.line, @raw.parsing_data.scenario.location.column)
-          else
-            @location ||= Location.new(@raw.parsing_data.location.line, @raw.parsing_data.location.column)
-        end
+        @location ||= Location.new(@raw.source_line, @raw.source_column)
       end
 
       def line

--- a/lib/turnip/node/rule.rb
+++ b/lib/turnip/node/rule.rb
@@ -16,14 +16,17 @@ module Turnip
     #
     class Rule < ScenarioGroupDefinition
       def children
-        @children ||= @raw[:children].map do |child|
-          unless child[:background].nil?
-            next Background.new(child[:background])
+        @children ||= @raw.children.map do |child|
+          if child.is_a?(CukeModeler::Background)
+            next Background.new(child)
           end
 
-          unless child[:scenario].nil?
-            klass = child.dig(:scenario, :examples).nil? ? Scenario : ScenarioOutline
-            next klass.new(child[:scenario])
+          if child.is_a?(CukeModeler::Scenario)
+            next Scenario.new(child)
+          end
+
+          if child.is_a?(CukeModeler::Outline)
+            next ScenarioOutline.new(child)
           end
         end.compact
       end

--- a/lib/turnip/node/scenario_definition.rb
+++ b/lib/turnip/node/scenario_definition.rb
@@ -9,11 +9,11 @@ module Turnip
       end
 
       def keyword
-        @raw[:keyword]
+        @raw.keyword
       end
 
       def description
-        @raw[:description]
+        @raw.description
       end
 
       def steps

--- a/lib/turnip/node/scenario_definition.rb
+++ b/lib/turnip/node/scenario_definition.rb
@@ -5,7 +5,7 @@ module Turnip
   module Node
     class ScenarioDefinition < Base
       def name
-        @raw[:name]
+        @raw.name
       end
 
       def keyword
@@ -17,7 +17,7 @@ module Turnip
       end
 
       def steps
-        @steps ||= @raw[:steps].map do |step|
+        @steps ||= @raw.steps.map do |step|
           Step.new(step)
         end
       end

--- a/lib/turnip/node/scenario_group_definition.rb
+++ b/lib/turnip/node/scenario_group_definition.rb
@@ -7,7 +7,7 @@ module Turnip
   module Node
     class ScenarioGroupDefinition < Base
       def name
-        @raw[:name]
+        @raw.name
       end
 
       def keyword

--- a/lib/turnip/node/scenario_group_definition.rb
+++ b/lib/turnip/node/scenario_group_definition.rb
@@ -11,11 +11,11 @@ module Turnip
       end
 
       def keyword
-        @raw[:keyword]
+        @raw.keyword
       end
 
       def description
-        @raw[:description]
+        @raw.description
       end
 
       def backgrounds

--- a/lib/turnip/node/scenario_outline.rb
+++ b/lib/turnip/node/scenario_outline.rb
@@ -20,7 +20,7 @@ module Turnip
       include HasTags
 
       def examples
-        @examples ||= @raw[:examples].map do |raw|
+        @examples ||= @raw.examples.map do |raw|
           Example.new(raw)
         end
       end
@@ -57,27 +57,27 @@ module Turnip
           header = example.header
 
           example.rows.map do |row|
-            metadata = convert_metadata_to_scenario(header, row)
+            scenario = convert_metadata_to_scenario(header, row)
 
             #
             # Replace <placeholder> using Example values
             #
-            metadata[:steps].each do |step|
-              step[:text] = substitute(step[:text], header, row)
+            scenario.steps.each do |step|
+              step.text = substitute(step.text, header, row)
 
               case
-              when step[:doc_string]
-                step[:doc_string][:content] = substitute(step[:doc_string][:content], header, row)
-              when step[:data_table]
-                step[:data_table][:rows].map do |table_row|
-                  table_row[:cells].map do |cell|
-                    cell[:value] = substitute(cell[:value], header, row)
+              when step.block&.is_a?(CukeModeler::DocString)
+                step.block.content = substitute(step.block.content, header, row)
+              when step.block&.is_a?(CukeModeler::Table)
+                step.block.rows.map do |table_row|
+                  table_row.cells.map do |cell|
+                    cell.value = substitute(cell.value, header, row)
                   end
                 end
               end
             end
 
-            Scenario.new(metadata)
+            Scenario.new(scenario)
           end
         end.flatten.compact
       end
@@ -117,11 +117,13 @@ module Turnip
       #
       def convert_metadata_to_scenario(header, row)
         # deep copy
-        Marshal.load(Marshal.dump(raw)).tap do |new_raw|
-          new_raw.delete(:examples)
-          new_raw[:name] = substitute(new_raw[:name], header, row)
-          new_raw[:type] = :Scenario
-          new_raw[:keyword] = 'Scenario'
+        original = Marshal.load(Marshal.dump(raw))
+
+        CukeModeler::Scenario.new.tap do |scenario|
+          scenario.name = substitute(original.name, header, row)
+          scenario.keyword = 'Scenario' # TODO: Do we need to worry about dialects other than English?
+          scenario.steps = original.steps
+          scenario.parsing_data = original.parsing_data
         end
       end
 

--- a/lib/turnip/node/scenario_outline.rb
+++ b/lib/turnip/node/scenario_outline.rb
@@ -123,7 +123,8 @@ module Turnip
           scenario.name = substitute(original.name, header, row)
           scenario.keyword = 'Scenario' # TODO: Do we need to worry about dialects other than English?
           scenario.steps = original.steps
-          scenario.parsing_data = original.parsing_data
+          scenario.source_line = original.source_line
+          scenario.source_column = original.source_column
         end
       end
 

--- a/lib/turnip/node/step.rb
+++ b/lib/turnip/node/step.rb
@@ -16,11 +16,12 @@ module Turnip
     #
     class Step < Base
       def keyword
-        @raw[:keyword]
+        # TODO: Do we want to keep the whitespace?
+        @raw.keyword + ' '
       end
 
       def text
-        @raw[:text]
+        @raw.text
       end
 
       #
@@ -32,10 +33,10 @@ module Turnip
 
       def argument
         @argument ||= case
-                      when @raw[:doc_string]
-                        doc_string(@raw[:doc_string])
-                      when @raw[:data_table]
-                        data_table(@raw[:data_table])
+                      when @raw.block&.is_a?(CukeModeler::DocString)
+                        doc_string(@raw.block)
+                      when @raw.block&.is_a?(CukeModeler::Table)
+                        data_table(@raw.block)
                       end
       end
 
@@ -46,13 +47,13 @@ module Turnip
       private
 
       def doc_string(doc)
-        doc[:content]
+        doc.content
       end
 
       def data_table(table)
-        rows = table[:rows].map do |row|
-          row[:cells].map do |cell|
-            cell[:value]
+        rows = table.rows.map do |row|
+          row.cells.map do |cell|
+            cell.value
           end
         end
         Turnip::Table.new(rows)

--- a/lib/turnip/node/tag.rb
+++ b/lib/turnip/node/tag.rb
@@ -13,7 +13,7 @@ module Turnip
     #
     class Tag < Base
       def name
-        @name ||= @raw[:name].gsub(/^@/, '')
+        @name ||= @raw.name.gsub(/^@/, '')
       end
     end
 
@@ -22,7 +22,7 @@ module Turnip
       # @return [Array] Array of Tag
       #
       def tags
-        @tags ||= @raw.fetch(:tags, []).map do |tag|
+        @tags ||= @raw.tags.map do |tag|
           Tag.new(tag)
         end
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -12,7 +12,7 @@ describe 'The CLI', :type => :integration do
   end
 
   it "prints out failures and successes" do
-    @result.should include('45 examples, 4 failures, 5 pending')
+    @result.should include('46 examples, 4 failures, 6 pending')
   end
 
   it "includes features in backtraces" do

--- a/spec/nodes/feature_spec.rb
+++ b/spec/nodes/feature_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Turnip::Node::Feature do
+  let(:feature) { Turnip::Builder.build(feature_file) }
+
+  context 'a file that specifies a language' do
+    let(:feature_file) { File.expand_path('../../examples/specific_language.feature', __dir__) }
+
+    it 'extracts the language' do
+      feature.language.should eq 'en-au'
+    end
+
+  end
+end

--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
-  s.add_runtime_dependency "cuke_modeler", "~> 3.14"
+  s.add_runtime_dependency "cuke_modeler", "~> 3.15"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"

--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
-  s.add_runtime_dependency "cucumber-gherkin", "~> 14.0"
+  s.add_runtime_dependency "cuke_modeler", "~> 3.2"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"

--- a/turnip.gemspec
+++ b/turnip.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rspec", [">=3.0", "<4.0"]
-  s.add_runtime_dependency "cuke_modeler", "~> 3.2"
+  s.add_runtime_dependency "cuke_modeler", "~> 3.14"
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
I saw #243 and just couldn't help myself.

It's a a larger change than just updating to the newest version of `cucumber-gherkin` because the idea is to no longer be tied to it so directly and go through [cuke_modeler](https://github.com/enkessler/cuke_modeler) instead because it's more stable. I didn't want to change too much, though, so I left all of the Turnip node classes instead of replacing them entirely with CukeModeler equivalents.