### PR TITLE
Send step notifications and add metadata for RSpec reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,24 @@ tags you'd use in Cucumber to switch between drivers e.g.  `@javascript` or
 metadata, so that Capybara is included and also any other extensions you might
 want to add.
 
+## RSpec custom formatters
+
+Turnip sends notifications to the RSpec reporter about step progress. You can
+listen for these by registering your formatter class with the following
+notifications:
+
+``` ruby
+class MyFormatter
+  RSpec::Core::Formatters.register self, :step_started, :step_passed, :step_failed, :step_pending
+  
+  def step_passed(step)
+    puts "Starting step: #{step.text}"
+  end
+
+  # …
+end
+```
+
 ## License
 
 (The MIT License)

--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -100,10 +100,11 @@ module Turnip
         end
 
         group.scenarios.each do |scenario|
-          step_names = (background_steps + scenario.steps).map(&:to_s)
-          description = step_names.join(' -> ')
+          all_steps = background_steps + scenario.steps
+          description = all_steps.map(&:to_s).join(' -> ')
+          metadata = scenario.metadata_hash.merge(turnip_steps: all_steps)
 
-          context.describe scenario.name, scenario.metadata_hash do
+          context.describe scenario.name, metadata do
             instance_eval <<-EOS, filename, scenario.line
               it description do
                 scenario.steps.each do |step|

--- a/lib/turnip/rspec.rb
+++ b/lib/turnip/rspec.rb
@@ -40,11 +40,16 @@ module Turnip
       include Turnip::Execute
 
       def run_step(feature_file, step)
+        reporter = ::RSpec.current_example.reporter
+        reporter.publish(:step_started, { step: step })
+
         begin
           instance_eval <<-EOS, feature_file, step.line
             step(step)
           EOS
         rescue Turnip::Pending => e
+          reporter.publish(:step_pending, { step: step })
+
           example = ::RSpec.current_example
           example.metadata[:line_number] = step.line
           example.metadata[:location] = "#{example.metadata[:file_path]}:#{step.line}"
@@ -56,9 +61,13 @@ module Turnip
 
           skip("No such step: '#{e}'")
         rescue StandardError, ::RSpec::Expectations::ExpectationNotMetError => e
+          reporter.publish(:step_failed, { step: step })
+
           e.backtrace.push "#{feature_file}:#{step.line}:in `#{step.description}'"
           raise e
         end
+
+        reporter.publish(:step_passed, { step: step })
       end
     end
 

--- a/spec/reporter_spec.rb
+++ b/spec/reporter_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+describe Turnip::RSpec::Execute do
+  let(:mod) { Module.new }
+  let(:obj) { Object.new.tap { |o| o.extend Turnip::RSpec::Execute; o.extend mod; def o.skip(*args); end } }
+  let(:reporter) { RSpec.current_example.reporter }
+
+  before { allow(reporter).to receive(:publish).and_call_original }
+
+  def create_step_node(text)
+    Turnip::Node::Step.new OpenStruct.new(source_line: 1, source_column: 0, text: text)
+  end
+
+  context '#run_step' do
+    it "publishes :step_started event when step is starting" do
+      step = create_step_node "a test step"
+
+      obj.run_step 'test.feature', step
+
+      expect(reporter).to have_received(:publish).with(:step_started, step: step)
+    end
+
+    it "publishes :step_passed event when step has passed" do
+      mod.step("a test step") { true }
+      step = create_step_node "a test step"
+
+      obj.run_step 'test.feature', step
+
+      expect(reporter).to have_received(:publish).with(:step_passed, step: step)
+    end
+
+    it "publishes :step_failed event when step has failed" do
+      mod.step("a failing step") { raise ::RSpec::Expectations::ExpectationNotMetError }
+      step = create_step_node "a failing step"
+
+      begin
+        obj.run_step 'test.feature', step
+      rescue ::RSpec::Expectations::ExpectationNotMetError => e
+      end
+
+      expect(reporter).to have_received(:publish).with(:step_failed, step: step)
+    end
+
+    it "publishes :step_pending event when step is pending" do
+      step = create_step_node "a pending step"
+
+      obj.run_step 'test.feature', step
+
+      expect(reporter).to have_received(:publish).with(:step_pending, step: step)
+    end
+  end
+end


### PR DESCRIPTION
Same as #245, that was merged but later reverted. I can't update that pull request anymore, so here's a new one.

Previous failing tests are fixed. Because of changes in #244, a step node used for testing had to be initialized differently.